### PR TITLE
[Feat] : 팜클럽 나가기 / 미션 피드 / 미션 인증 화면 구현

### DIFF
--- a/assets/image/ic_alert_circle.svg
+++ b/assets/image/ic_alert_circle.svg
@@ -1,0 +1,10 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1224_6511)">
+<path d="M9 6V9M9 12H9.0075M16.5 9C16.5 13.1421 13.1421 16.5 9 16.5C4.85786 16.5 1.5 13.1421 1.5 9C1.5 4.85786 4.85786 1.5 9 1.5C13.1421 1.5 16.5 4.85786 16.5 9Z" stroke="#FF4040" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_1224_6511">
+<rect width="18" height="18" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/assets/image/ic_close.svg
+++ b/assets/image/ic_close.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18M6 6L18 18" stroke="#1D1D1D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/common/bottom_sheet/bottom_sheet_farmclub_exit.dart
+++ b/lib/common/bottom_sheet/bottom_sheet_farmclub_exit.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:get/get.dart';
+import 'package:mojacknong_android/common/bouncing.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/component/button_brown.dart';
+import 'package:mojacknong_android/view_model/controllers/bottom_sheet_controller.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_controller.dart';
+
+class BottomSheetFarmclubExit extends StatefulWidget {
+  const BottomSheetFarmclubExit({super.key});
+
+  @override
+  State<BottomSheetFarmclubExit> createState() =>
+      _BottomSheetFarmclubExitState();
+}
+
+class _BottomSheetFarmclubExitState extends State<BottomSheetFarmclubExit> {
+  final FarmclubController _farmclubController = Get.find();
+  BottomSheetController _bottomSheetController = BottomSheetController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        SizedBox(
+          height: 30,
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 32),
+          child: Text("팜클럽을 나가시겠어요?", style: FarmusThemeData.darkStyle18),
+        ),
+        SizedBox(
+          height: 16,
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 16.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SvgPicture.asset("assets/image/ic_alert_circle.svg"),
+              SizedBox(
+                width: 4,
+              ),
+              Text(
+                "지금까지의 팜클럽 기록이 모두 사라져요",
+                style: FarmusThemeData.redStyle,
+              ),
+            ],
+          ),
+        ),
+        SizedBox(
+          height: 16,
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Container(
+            child: Row(
+              children: [
+                Expanded(
+                  child: Bouncing(
+                    child: GestureDetector(
+                      onTap: () {
+                        _farmclubController.toggleSelectTextBox(0);
+                        _farmclubController.toggleShouldExit();
+                      },
+                      child: Obx(
+                        () => Container(
+                          width: double.infinity,
+                          height: 140,
+                          decoration: BoxDecoration(
+                            color: _farmclubController.isTextBox1Selected.value
+                                ? FarmusThemeData.background
+                                : FarmusThemeData.white,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: FarmusThemeData.grey4),
+                          ),
+                          child: Center(
+                            child: Text(
+                              "채소를 더 이상\n키우지 않아요",
+                              style: FarmusThemeData.darkStyle14,
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: 8,
+                ),
+                Expanded(
+                  child: Bouncing(
+                    child: GestureDetector(
+                      onTap: () {
+                        _farmclubController.toggleSelectTextBox(1);
+                        _farmclubController.toggleShouldExit();
+                      },
+                      child: Obx(
+                        () => Container(
+                          width: double.infinity,
+                          height: 140,
+                          decoration: BoxDecoration(
+                            color: _farmclubController.isTextBox2Selected.value
+                                ? FarmusThemeData.background
+                                : FarmusThemeData.white,
+                            borderRadius: BorderRadius.circular(8),
+                            border: Border.all(color: FarmusThemeData.grey4),
+                          ),
+                          child: Center(
+                            child: Text(
+                              "채소는 계속\n키우지만 팜클럽은\n나가고 싶어요",
+                              style: FarmusThemeData.darkStyle14,
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        SizedBox(
+          height: 16,
+        ),
+        Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: Obx(() => ButtonBrown(
+                text: "나가기",
+                enabled: (_farmclubController.isTextBox1Selected.value ||
+                        _farmclubController.isTextBox2Selected.value)
+                    .obs,
+                onPress: () {
+                  print("버튼");
+                  if (Navigator.canPop(context)) {
+                    Navigator.pop(context);
+                  }
+                },
+              )),
+        ),
+        SizedBox(
+          height: 30,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/common/bouncing.dart
+++ b/lib/common/bouncing.dart
@@ -22,7 +22,7 @@ class _BouncingState extends State<Bouncing>
       vsync: this,
       duration: Duration(milliseconds: 100),
       lowerBound: 0.0,
-      upperBound: 0.1,
+      upperBound: 0.05,
     );
     _controller.addListener(() {
       setState(() {});

--- a/lib/common/custom_app_bar.dart
+++ b/lib/common/custom_app_bar.dart
@@ -2,10 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
-  final String? title;
-
-  CustomAppBar({this.title});
-
   @override
   Size get preferredSize => const Size.fromHeight(0);
 
@@ -18,16 +14,6 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
         leading: const BackButton(
           color: FarmusThemeData.black,
         ),
-        title: title != null
-            ? Text(
-                title!,
-                style: TextStyle(
-                  color: FarmusThemeData.dark,
-                  fontFamily: "Pretendard",
-                  fontSize: 16,
-                ),
-              )
-            : null,
         backgroundColor: FarmusThemeData.white,
       ),
     );

--- a/lib/common/custom_app_bar.dart
+++ b/lib/common/custom_app_bar.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 
 class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String? title;
+
+  CustomAppBar({this.title});
+
   @override
   Size get preferredSize => const Size.fromHeight(0);
 
@@ -14,6 +18,16 @@ class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
         leading: const BackButton(
           color: FarmusThemeData.black,
         ),
+        title: title != null
+            ? Text(
+                title!,
+                style: TextStyle(
+                  color: FarmusThemeData.dark,
+                  fontFamily: "Pretendard",
+                  fontSize: 16,
+                ),
+              )
+            : null,
         backgroundColor: FarmusThemeData.white,
       ),
     );

--- a/lib/common/dialog/Dialog_join_farmclub.dart
+++ b/lib/common/dialog/Dialog_join_farmclub.dart
@@ -4,7 +4,10 @@ import 'package:mojacknong_android/common/farmus_theme_data.dart';
 
 class DialogJoinFarmclub extends StatefulWidget {
   final String title;
-  const DialogJoinFarmclub({super.key, required this.title});
+  final String content;
+
+  const DialogJoinFarmclub(
+      {super.key, required this.title, required this.content});
 
   @override
   State<DialogJoinFarmclub> createState() => _DialogJoinFarmclubState();
@@ -56,7 +59,7 @@ class _DialogJoinFarmclubState extends State<DialogJoinFarmclub> {
                         width: 8,
                       ),
                       Text(
-                        "팜클럽에 가입했어요",
+                        widget.content,
                         style: FarmusThemeData.darkStyle16,
                       ),
                     ],

--- a/lib/common/farmus_theme_data.dart
+++ b/lib/common/farmus_theme_data.dart
@@ -127,4 +127,10 @@ class FarmusThemeData {
     fontSize: 14,
     fontFamily: "Pretendard",
   );
+
+  static const TextStyle redStyle = TextStyle(
+    color: FarmusThemeData.red,
+    fontSize: 14,
+    fontFamily: "Pretendard",
+  );
 }

--- a/lib/data/network/mypage_api_service.dart
+++ b/lib/data/network/mypage_api_service.dart
@@ -1,26 +1,28 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
+
 
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:mojacknong_android/data/network/base_api_services.dart';
 import 'package:mojacknong_android/model/farmus_user.dart';
 
+import '../../model/mypage_history.dart';
+
 const storage = FlutterSecureStorage();
 
 
 class MypageApiService {
+
   FutureOr<FarmusUser?> getUser() async {
     try {
       Response response = await ApiClient().dio.get('/api/user');
-      print(134);
-      print(response.data["data"]);
+
+
       if (response.data["data"] != null) {
-      //  final userData = response.data["data"];
+
         final userData = FarmusUser.fromJson(response.data["data"]);
 
-         print(userData);
+   //      print(userData);
         return userData;
       }
     } on DioException catch (e) {
@@ -29,7 +31,26 @@ class MypageApiService {
 
     }
     return null;
+  }
 
+  FutureOr<MypageHistory?> getHistory() async {
+    try {
+      Response response = await ApiClient().dio.get('/api/crop/history');
+
+
+      if (response.data["data"] != null) {
+        //  final userData = response.data["data"];
+        final historyData = MypageHistory.fromJson(response.data["data"]);
+
+    //    print(historyData);
+        return historyData;
+      }
+    } on DioException catch (e) {
+      print(e.message);
+      print("팜 히스토리 조회 실패");
+
+    }
+    return null;
   }
 
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_template.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/firebase_options.dart';
-import 'package:mojacknong_android/view/login/login_screen.dart';
+import 'package:mojacknong_android/view/main/main_screen.dart';
 
 Future<void> main() async {
   // 웹 환경에서 카카오 로그인을 정상적으로 완료하기 위함
@@ -23,7 +23,7 @@ Future<void> main() async {
   runApp(
     MaterialApp(
       title: "Farmus",
-      home: const LoginScreen(),
+      home: const MainScreen(),
       debugShowCheckedModeBanner: false,
       theme: ThemeData(fontFamily: 'Pretendard'),
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_template.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/firebase_options.dart';
-import 'package:mojacknong_android/view/main/main_screen.dart';
+import 'package:mojacknong_android/view/login/login_screen.dart';
 
 Future<void> main() async {
   // 웹 환경에서 카카오 로그인을 정상적으로 완료하기 위함
@@ -23,7 +23,7 @@ Future<void> main() async {
   runApp(
     MaterialApp(
       title: "Farmus",
-      home: const MainScreen(),
+      home: const LoginScreen(),
       debugShowCheckedModeBanner: false,
       theme: ThemeData(fontFamily: 'Pretendard'),
     ),

--- a/lib/model/history_detail.dart
+++ b/lib/model/history_detail.dart
@@ -1,0 +1,28 @@
+
+
+class HistoryDetail {
+
+  final String detailId;
+  final String image;
+  final String veggieName;
+  final String name;
+  final String period;
+
+  HistoryDetail({
+    required this.detailId,
+    required this.image,
+    required this.veggieName,
+    required this.name,
+    required this.period,
+  });
+
+  factory HistoryDetail.fromJson(Map<String, dynamic> json) {
+    return HistoryDetail(
+      detailId: json['detailId'],
+      image: json['image'],
+      veggieName: json['veggieName'],
+      name: json['name'],
+      period: json['period'],
+    );
+  }
+}

--- a/lib/model/mypage_history.dart
+++ b/lib/model/mypage_history.dart
@@ -1,0 +1,39 @@
+
+
+
+import 'package:mojacknong_android/model/history_detail.dart';
+
+class MypageHistory {
+  final String historyId;
+  final List<HistoryDetail> veggieHistoryDetailList;
+  final List<HistoryDetail> farmClubHistoryDetailList;
+
+
+  MypageHistory({
+    required this.historyId,
+    List<HistoryDetail>? veggieHistoryDetailList,
+    List<HistoryDetail>? farmClubHistoryDetailList
+
+  }): veggieHistoryDetailList = veggieHistoryDetailList ?? [],
+      farmClubHistoryDetailList = farmClubHistoryDetailList ?? [] ;
+
+  factory MypageHistory.fromJson(Map<String, dynamic> json) {
+    return MypageHistory(
+      historyId: json['historyId'],
+      veggieHistoryDetailList: (json['veggieHistoryDetails'] != null)
+          ? List<HistoryDetail>.from(
+        json['veggieHistoryDetails'].map(
+              (x) => HistoryDetail.fromJson(x),
+        ),
+      )
+          : [],
+      farmClubHistoryDetailList: (json['farmClubHistoryDetails'] != null)
+          ? List<HistoryDetail>.from(
+        json['farmClubHistoryDetails'].map(
+              (x) => HistoryDetail.fromJson(x),
+        ),
+      )
+          : [],
+    );
+  }
+}

--- a/lib/repository/mypage_repository.dart
+++ b/lib/repository/mypage_repository.dart
@@ -3,6 +3,7 @@
 import 'package:mojacknong_android/model/farmus_user.dart';
 
 import '../data/network/mypage_api_service.dart';
+import '../model/mypage_history.dart';
 
 class MypageRepository {
 
@@ -12,6 +13,24 @@ class MypageRepository {
 
     return response;
   }
+
+
+  static Future<MypageHistory?> getHistoryApi() async {
+
+    final response = await MypageApiService().getHistory();
+
+    return response;
+  }
+
+  static Future<List<dynamic>> getMyPageData() async {
+    final List<Future<dynamic>> futures = [
+      getUserApi(),
+      getHistoryApi()
+    ];
+    return Future.wait(futures);
+  }
+
+
 
 
 }

--- a/lib/view/community/component/image_add.dart
+++ b/lib/view/community/component/image_add.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+
+class ImageAdd extends StatefulWidget {
+  final String title;
+  const ImageAdd({super.key, required this.title});
+
+  @override
+  State<ImageAdd> createState() => _ImageAddState();
+}
+
+class _ImageAddState extends State<ImageAdd> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SvgPicture.asset(
+          "assets/image/ic_camera.svg",
+        ),
+        const SizedBox(
+          height: 8,
+        ),
+        Text(
+          widget.title,
+          style: FarmusThemeData.grey2Style14,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/community/post/post_screen.dart
+++ b/lib/view/community/post/post_screen.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
@@ -10,6 +9,7 @@ import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/model/posting.dart';
 import 'package:mojacknong_android/repository/community_repository.dart';
 import 'package:mojacknong_android/view/community/component/category_list.dart';
+import 'package:mojacknong_android/view/community/component/image_add.dart';
 import 'package:mojacknong_android/view_model/controllers/community_feed_controller.dart';
 import 'package:mojacknong_android/view_model/controllers/community_post_controller.dart';
 
@@ -180,19 +180,8 @@ class _PostScreenState extends State<PostScreen> {
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 crossAxisAlignment: CrossAxisAlignment.center,
                                 children: [
-                                  SvgPicture.asset(
-                                    "assets/image/ic_camera.svg",
-                                  ),
-                                  const SizedBox(
-                                    height: 8,
-                                  ),
-                                  const Text(
-                                    "사진 추가하기",
-                                    style: TextStyle(
-                                      color: FarmusThemeData.grey2,
-                                      fontSize: 14,
-                                      fontFamily: "Pretendard",
-                                    ),
+                                  ImageAdd(
+                                    title: "사진 추가하기",
                                   ),
                                 ],
                               ),

--- a/lib/view/farmclub/component/button_brown.dart
+++ b/lib/view/farmclub/component/button_brown.dart
@@ -24,9 +24,10 @@ class ButtonBrown extends StatelessWidget {
           text: text,
           backgroundColor: enabled.value
               ? FarmusThemeData.brownButton
-              : FarmusThemeData.grey4,
+              : FarmusThemeData.grey3,
           foregroundColor:
-              enabled.value ? FarmusThemeData.white : FarmusThemeData.grey2,
+              enabled.value ? FarmusThemeData.white : FarmusThemeData.white,
+          onPressed: enabled.value ? onPress : null,
         ),
       );
     });

--- a/lib/view/farmclub/component/challenge/challenge_feed.dart
+++ b/lib/view/farmclub/component/challenge/challenge_feed.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_mission_feed_screen.dart';
 
 class ChallengeFeed extends StatefulWidget {
   const ChallengeFeed({super.key});
@@ -62,36 +63,48 @@ class _ChallengeFeedState extends State<ChallengeFeed> {
               SizedBox(
                 height: 4,
               ),
-              Container(
-                width: double.infinity,
-                height: 98,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: Stack(
-                    children: [
-                      Image.asset(
-                        "assets/image/image_challenge2.png",
-                        fit: BoxFit.cover,
-                        width: double.infinity,
-                        height: double.infinity,
-                      ),
-                      Positioned.fill(
-                        child: Container(
-                          decoration: BoxDecoration(
-                            color: Colors.black.withOpacity(0.5),
-                          ),
-                          child: Center(
-                            child: Text(
-                              "더보기",
-                              style: FarmusThemeData.whiteStyle14,
+              GestureDetector(
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return FarmclubMissionFeedScreen();
+                      },
+                    ),
+                  );
+                },
+                child: Container(
+                  width: double.infinity,
+                  height: 98,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Stack(
+                      children: [
+                        Image.asset(
+                          "assets/image/image_challenge2.png",
+                          fit: BoxFit.cover,
+                          width: double.infinity,
+                          height: double.infinity,
+                        ),
+                        Positioned.fill(
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Colors.black.withOpacity(0.5),
+                            ),
+                            child: Center(
+                              child: Text(
+                                "더보기",
+                                style: FarmusThemeData.whiteStyle14,
+                              ),
                             ),
                           ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
               ),

--- a/lib/view/farmclub/component/challenge/challenge_help.dart
+++ b/lib/view/farmclub/component/challenge/challenge_help.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_help_screen.dart';
 
 class ChallengeHelp extends StatelessWidget {
   final String help;
@@ -13,24 +14,36 @@ class ChallengeHelp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: Container(
-        alignment: Alignment.centerLeft,
-        width: double.infinity,
-        height: 45,
-        decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
-            color: FarmusThemeData.brown3),
-        child: Row(
-          children: [
-            SizedBox(
-              width: 16,
+      child: GestureDetector(
+        onTap: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) {
+                return FarmclubHelpScreen();
+              },
             ),
-            Text(
-              "도움말   $help",
-              textAlign: TextAlign.start,
-              style: FarmusThemeData.brownText13,
-            ),
-          ],
+          );
+        },
+        child: Container(
+          alignment: Alignment.centerLeft,
+          width: double.infinity,
+          height: 45,
+          decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              color: FarmusThemeData.brown3),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 16,
+              ),
+              Text(
+                "도움말   $help",
+                textAlign: TextAlign.start,
+                style: FarmusThemeData.brownText13,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/view/farmclub/component/challenge/challenge_step.dart
+++ b/lib/view/farmclub/component/challenge/challenge_step.dart
@@ -5,12 +5,10 @@ import 'package:mojacknong_android/common/farmus_theme_data.dart';
 class ChallengeStep extends StatefulWidget {
   final String step;
   final String title;
+  final Color? color;
 
-  const ChallengeStep({
-    super.key,
-    required this.step,
-    required this.title,
-  });
+  const ChallengeStep(
+      {super.key, required this.step, required this.title, this.color});
 
   @override
   State<ChallengeStep> createState() => _ChallengeStepState();
@@ -28,7 +26,13 @@ class _ChallengeStepState extends State<ChallengeStep> {
             ),
             Text(
               "Step ${widget.step}",
-              style: FarmusThemeData.brownText14,
+              style: TextStyle(
+                fontFamily: "Pretendard",
+                fontSize: 14,
+                color: widget.color == null
+                    ? FarmusThemeData.brownText
+                    : widget.color,
+              ),
             ),
             SizedBox(
               width: 8,

--- a/lib/view/farmclub/component/farmclub_help.dart
+++ b/lib/view/farmclub/component/farmclub_help.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_step.dart';
+
+class FarmclubHelp extends StatelessWidget {
+  const FarmclubHelp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ChallengeStep(
+          step: "0",
+          title: "준비물을 챙겨요",
+          color: FarmusThemeData.dark,
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Text(
+            "상추 씨앗과 상토, 재배 용기를 준비해 주세요\n베란다에서는 로메인 상추가 잘 자라요\n씨앗은 2달, 모종은 1달 후에 먹을 수 있어요\n모종은 4~5월, 9~10월에 판매해요",
+            style: FarmusThemeData.darkStyle14,
+            textAlign: TextAlign.left,
+          ),
+        ),
+        SizedBox(
+          height: 16,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/farmclub/component/farmclub_title.dart
+++ b/lib/view/farmclub/component/farmclub_title.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/bottom_sheet_controller.dart';
 
 class FarmclubTitle extends StatefulWidget {
   const FarmclubTitle({super.key});
@@ -11,6 +12,8 @@ class FarmclubTitle extends StatefulWidget {
 }
 
 class _FarmclubTitleState extends State<FarmclubTitle> {
+  BottomSheetController bottomSheetController = BottomSheetController();
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -38,10 +41,16 @@ class _FarmclubTitleState extends State<FarmclubTitle> {
               const Spacer(),
               Bouncing(
                 onPress: () {},
-                child: SvgPicture.asset(
-                  "assets/image/ic_more_vertical.svg",
+                child: GestureDetector(
+                  onTap: () {
+                    bottomSheetController.showFarmclubExitBottomSheet(
+                        context, "");
+                  },
+                  child: SvgPicture.asset(
+                    "assets/image/ic_more_vertical.svg",
+                  ),
                 ),
-              )
+              ),
             ],
           ),
         ],

--- a/lib/view/farmclub/component/mission_feed.dart
+++ b/lib/view/farmclub/component/mission_feed.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/component/record/record_picture.dart';
+import 'package:mojacknong_android/view/farmclub/component/record/record_profile.dart';
+
+class MissionFeed extends StatefulWidget {
+  const MissionFeed({super.key});
+
+  @override
+  State<MissionFeed> createState() => _MissionFeedState();
+}
+
+class _MissionFeedState extends State<MissionFeed> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(
+          height: 16,
+        ),
+        RecordProfile(nickname: "파머시치", postTime: "10/29 4:12"),
+        SizedBox(
+          height: 8,
+        ),
+        RecordPicture(like: 2.obs),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Text(
+            "오늘 상훈이를 심어줬어요. 앞으로 잘 자라겠죠? 다들 응원 부탁드립니다 :)",
+            style: FarmusThemeData.darkStyle14,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/farmclub/farmclub_auth_screen.dart
+++ b/lib/view/farmclub/farmclub_auth_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/primary_app_bar.dart';
+
+class FarmclubAuthScreen extends StatefulWidget {
+  const FarmclubAuthScreen({super.key});
+
+  @override
+  State<FarmclubAuthScreen> createState() => _FarmclubAuthScreenState();
+}
+
+class _FarmclubAuthScreenState extends State<FarmclubAuthScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PrimaryAppBar(
+        title: "미션 인증",
+      ),
+    );
+  }
+}

--- a/lib/view/farmclub/farmclub_auth_screen.dart
+++ b/lib/view/farmclub/farmclub_auth_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 
 class FarmclubAuthScreen extends StatefulWidget {
@@ -15,6 +16,7 @@ class _FarmclubAuthScreenState extends State<FarmclubAuthScreen> {
       appBar: PrimaryAppBar(
         title: "미션 인증",
       ),
+      backgroundColor: FarmusThemeData.white,
     );
   }
 }

--- a/lib/view/farmclub/farmclub_auth_screen.dart
+++ b/lib/view/farmclub/farmclub_auth_screen.dart
@@ -1,6 +1,15 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
+import 'package:mojacknong_android/view/community/component/image_add.dart';
+import 'package:mojacknong_android/view/farmclub/component/button_brown.dart';
+import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_step.dart';
+import 'package:mojacknong_android/view_model/controllers/bottom_sheet_controller.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_controller.dart';
 
 class FarmclubAuthScreen extends StatefulWidget {
   const FarmclubAuthScreen({super.key});
@@ -10,6 +19,25 @@ class FarmclubAuthScreen extends StatefulWidget {
 }
 
 class _FarmclubAuthScreenState extends State<FarmclubAuthScreen> {
+  FarmclubController farmclubController = Get.put(FarmclubController());
+  BottomSheetController bottomSheetController =
+      Get.put(BottomSheetController());
+
+  final ImagePicker _picker = ImagePicker();
+  File? _selectedImage;
+
+  void _getImageFromGallery(ImageSource source) async {
+    final XFile? pickedFile = await _picker.pickImage(source: source);
+
+    if (pickedFile != null) {
+      setState(() {
+        _selectedImage = File(pickedFile.path);
+      });
+    }
+
+    farmclubController.image.value = _selectedImage;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -17,6 +45,106 @@ class _FarmclubAuthScreenState extends State<FarmclubAuthScreen> {
         title: "미션 인증",
       ),
       backgroundColor: FarmusThemeData.white,
+      body: Column(
+        children: [
+          const SizedBox(
+            height: 8,
+          ),
+          const ChallengeStep(step: "0", title: "준비물을 챙겨요"),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: GestureDetector(
+              onTap: () {
+                _getImageFromGallery(
+                  ImageSource.gallery,
+                );
+              },
+              child: Container(
+                width: double.infinity,
+                height: 248,
+                decoration: BoxDecoration(
+                  color: FarmusThemeData.pictureBackground,
+                  borderRadius: BorderRadius.circular(16),
+                  image: _selectedImage != null
+                      ? DecorationImage(
+                          image: FileImage(_selectedImage!),
+                          fit: BoxFit.cover,
+                        )
+                      : null,
+                ),
+                child: _selectedImage == null
+                    ? const Center(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
+                            ImageAdd(
+                              title: "인증 사진 추가하기",
+                            ),
+                          ],
+                        ),
+                      )
+                    : null,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: TextFormField(
+              maxLines: null,
+              decoration: const InputDecoration(
+                hintText: '인증 글을 작성해주세요',
+                hintStyle: FarmusThemeData.grey2Style13,
+                counterText: "",
+                focusedBorder: InputBorder.none,
+                enabledBorder: InputBorder.none,
+              ),
+              maxLength: 50,
+              onChanged: farmclubController.updateContentValue,
+            ),
+          ),
+        ],
+      ),
+      floatingActionButtonLocation:
+          FloatingActionButtonLocation.miniCenterFloat,
+      floatingActionButton: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Column(
+          children: [
+            const Expanded(
+                child: SizedBox(
+              height: 0,
+            )),
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(vertical: 16.0, horizontal: 8.0),
+              child: Align(
+                alignment: Alignment.bottomRight,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 8.0),
+                  child: Obx(
+                    () => Text(
+                      "${farmclubController.contentValue.value.length} / 50",
+                      style: TextStyle(
+                        color: FarmusThemeData.dark.withOpacity(0.3),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            ButtonBrown(
+              text: "업로드하기",
+              enabled: farmclubController.isFormVaild,
+              onPress: () {
+                Navigator.pop(context);
+                bottomSheetController.showAuthDialog(
+                    context, "상추 좋아하세요", "Step 0을 완료했어요");
+              },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/view/farmclub/farmclub_challenge_screen.dart
+++ b/lib/view/farmclub/farmclub_challenge_screen.dart
@@ -8,6 +8,7 @@ import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_f
 import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_help.dart';
 import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_step.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_title_with_divider.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_auth_screen.dart';
 import 'package:mojacknong_android/view/farmclub/my_farmclub_mission_screen.dart';
 
 class FarmclubChallengeScreen extends StatefulWidget {
@@ -130,6 +131,16 @@ class _FarmclubChallengeScreenState extends State<FarmclubChallengeScreen> {
               child: ButtonBrown(
                 text: "미션 인증하기",
                 enabled: RxBool(true),
+                onPress: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return FarmclubAuthScreen();
+                      },
+                    ),
+                  );
+                },
               ),
             ),
           ],

--- a/lib/view/farmclub/farmclub_help_screen.dart
+++ b/lib/view/farmclub/farmclub_help_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/custom_app_bar.dart';
+
+class FarmclubHelpScreen extends StatelessWidget {
+  const FarmclubHelpScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(
+        title: "미션 피드",
+      ),
+    );
+  }
+}

--- a/lib/view/farmclub/farmclub_help_screen.dart
+++ b/lib/view/farmclub/farmclub_help_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
 import 'package:mojacknong_android/common/custom_app_bar.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/component/farmclub_help.dart';
 
 class FarmclubHelpScreen extends StatelessWidget {
   const FarmclubHelpScreen({super.key});
@@ -7,8 +10,50 @@ class FarmclubHelpScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomAppBar(
-        title: "미션 피드",
+      appBar: CustomAppBar(),
+      backgroundColor: FarmusThemeData.white,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: 16,
+                ),
+                Text(
+                  "도움말",
+                  style: FarmusThemeData.darkStyle16,
+                ),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.pop(context);
+                  },
+                  child: SvgPicture.asset("assets/image/ic_close.svg"),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                  FarmclubHelp(),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/view/farmclub/farmclub_mission_feed_screen.dart
+++ b/lib/view/farmclub/farmclub_mission_feed_screen.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:mojacknong_android/common/custom_app_bar.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_help.dart';
+import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_step.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_help_screen.dart';
 
 class FarmclubMissionFeedScreen extends StatefulWidget {
   const FarmclubMissionFeedScreen({super.key});
@@ -11,6 +17,54 @@ class FarmclubMissionFeedScreen extends StatefulWidget {
 class _FarmclubMissionFeedScreenState extends State<FarmclubMissionFeedScreen> {
   @override
   Widget build(BuildContext context) {
-    return Container();
+    return Scaffold(
+      appBar: CustomAppBar(),
+      backgroundColor: FarmusThemeData.white,
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: 16,
+                ),
+                Text(
+                  "미션 피드",
+                  style: FarmusThemeData.darkStyle16,
+                ),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.pop(context);
+                  },
+                  child: SvgPicture.asset("assets/image/ic_close.svg"),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(
+            height: 16,
+          ),
+          ChallengeStep(step: "0", title: "준비물을 챙겨요"),
+          SizedBox(
+            height: 16,
+          ),
+          GestureDetector(
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) {
+                      return FarmclubHelpScreen();
+                    },
+                  ),
+                );
+              },
+              child: ChallengeHelp(help: "상추를 키울 때에는 어쩌고저쩌고 해야해요.")),
+        ],
+      ),
+    );
   }
 }

--- a/lib/view/farmclub/farmclub_mission_feed_screen.dart
+++ b/lib/view/farmclub/farmclub_mission_feed_screen.dart
@@ -8,6 +8,7 @@ import 'package:mojacknong_android/view/farmclub/component/button_white.dart';
 import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_help.dart';
 import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_step.dart';
 import 'package:mojacknong_android/view/farmclub/component/mission_feed.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_auth_screen.dart';
 import 'package:mojacknong_android/view/farmclub/my_farmclub_mission_screen.dart';
 
 class FarmclubMissionFeedScreen extends StatefulWidget {
@@ -103,6 +104,16 @@ class _FarmclubMissionFeedScreenState extends State<FarmclubMissionFeedScreen> {
               child: ButtonBrown(
                 text: "미션 인증하기",
                 enabled: RxBool(true),
+                onPress: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return FarmclubAuthScreen();
+                      },
+                    ),
+                  );
+                },
               ),
             ),
           ],

--- a/lib/view/farmclub/farmclub_mission_feed_screen.dart
+++ b/lib/view/farmclub/farmclub_mission_feed_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class FarmclubMissionFeedScreen extends StatefulWidget {
+  const FarmclubMissionFeedScreen({super.key});
+
+  @override
+  State<FarmclubMissionFeedScreen> createState() =>
+      _FarmclubMissionFeedScreenState();
+}
+
+class _FarmclubMissionFeedScreenState extends State<FarmclubMissionFeedScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/lib/view/farmclub/farmclub_mission_feed_screen.dart
+++ b/lib/view/farmclub/farmclub_mission_feed_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:get/get.dart';
 import 'package:mojacknong_android/common/custom_app_bar.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/component/button_brown.dart';
+import 'package:mojacknong_android/view/farmclub/component/button_white.dart';
 import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_help.dart';
 import 'package:mojacknong_android/view/farmclub/component/challenge/challenge_step.dart';
-import 'package:mojacknong_android/view/farmclub/farmclub_help_screen.dart';
+import 'package:mojacknong_android/view/farmclub/component/mission_feed.dart';
+import 'package:mojacknong_android/view/farmclub/my_farmclub_mission_screen.dart';
 
 class FarmclubMissionFeedScreen extends StatefulWidget {
   const FarmclubMissionFeedScreen({super.key});
@@ -44,26 +48,65 @@ class _FarmclubMissionFeedScreenState extends State<FarmclubMissionFeedScreen> {
               ],
             ),
           ),
-          SizedBox(
-            height: 16,
-          ),
-          ChallengeStep(step: "0", title: "준비물을 챙겨요"),
-          SizedBox(
-            height: 16,
-          ),
-          GestureDetector(
-              onTap: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) {
-                      return FarmclubHelpScreen();
-                    },
+          Expanded(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  SizedBox(
+                    height: 16,
                   ),
-                );
-              },
-              child: ChallengeHelp(help: "상추를 키울 때에는 어쩌고저쩌고 해야해요.")),
+                  ChallengeStep(step: "0", title: "준비물을 챙겨요"),
+                  SizedBox(
+                    height: 16,
+                  ),
+                  ChallengeHelp(help: "상추를 키울 때에는 어쩌고저쩌고 해야해요."),
+                  SizedBox(
+                    height: 8,
+                  ),
+                  MissionFeed(),
+                  MissionFeed(),
+                  MissionFeed(),
+                  SizedBox(
+                    height: 70,
+                  ),
+                ],
+              ),
+            ),
+          ),
         ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
+      floatingActionButton: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 16),
+        color: Colors.transparent,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Expanded(
+              flex: 1,
+              child: ButtonWhite(
+                  text: "내 미션",
+                  onPress: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) {
+                          return const MyFarmclubMissionScreen();
+                        },
+                      ),
+                    );
+                  }),
+            ),
+            Expanded(
+              flex: 2,
+              child: ButtonBrown(
+                text: "미션 인증하기",
+                enabled: RxBool(true),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/farmclub/farmclub_mission_screen.dart
+++ b/lib/view/farmclub/farmclub_mission_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class FarmclubMissionScreen extends StatefulWidget {
+  const FarmclubMissionScreen({super.key});
+
+  @override
+  State<FarmclubMissionScreen> createState() => _FarmclubMissionScreenState();
+}
+
+class _FarmclubMissionScreenState extends State<FarmclubMissionScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/lib/view/farmclub/farmclub_screen.dart
+++ b/lib/view/farmclub/farmclub_screen.dart
@@ -132,20 +132,8 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                         const SizedBox(
                           height: 16,
                         ),
-                        GestureDetector(
-                          onTap: () {
-                            Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) {
-                                  return const FarmclubChallengeScreen();
-                                },
-                              ),
-                            );
-                          },
-                          child: const ChallengeHelp(
-                            help: "상추 씨앗과 상토, 재배 용기를 준비해 주세요",
-                          ),
+                        ChallengeHelp(
+                          help: "상추 씨앗과 상토, 재배 용기를 준비해 주세요",
                         ),
                         const SizedBox(
                           height: 16,

--- a/lib/view/farmclub/farmclub_screen.dart
+++ b/lib/view/farmclub/farmclub_screen.dart
@@ -18,6 +18,7 @@ import 'package:mojacknong_android/view/farmclub/component/my_farmclub_info.dart
 import 'package:mojacknong_android/view/farmclub/component/my_farmclub_list.dart';
 import 'package:mojacknong_android/view/farmclub/component/record/record_picture.dart';
 import 'package:mojacknong_android/view/farmclub/component/record/record_profile.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_auth_screen.dart';
 import 'package:mojacknong_android/view/farmclub/farmclub_challenge_screen.dart';
 import 'package:mojacknong_android/view/farmclub/farmclub_explore_screen.dart';
 import 'package:mojacknong_android/view/farmclub/farmclub_record_screen.dart';
@@ -253,6 +254,16 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                     child: ButtonBrown(
                       text: "미션 인증하기",
                       enabled: RxBool(true),
+                      onPress: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) {
+                              return FarmclubAuthScreen();
+                            },
+                          ),
+                        );
+                      },
                     ),
                   ),
                 ],

--- a/lib/view/farmclub/farmclub_screen.dart
+++ b/lib/view/farmclub/farmclub_screen.dart
@@ -48,7 +48,7 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
+                const Text(
                   "나의 팜클럽",
                   style: TextStyle(
                     color: FarmusThemeData.dark,
@@ -64,7 +64,7 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                         context,
                         MaterialPageRoute(
                           builder: (context) {
-                            return FarmclubExploreScreen();
+                            return const FarmclubExploreScreen();
                           },
                         ),
                       );
@@ -83,53 +83,53 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        SizedBox(
+                        const SizedBox(
                           height: 8,
                         ),
                         MyFarmclubList(),
-                        SizedBox(
+                        const SizedBox(
                           height: 16,
                         ),
-                        FarmclubTitle(),
-                        SizedBox(
+                        const FarmclubTitle(),
+                        const SizedBox(
                           height: 8,
                         ),
-                        FarmclubContent(
+                        const FarmclubContent(
                             content:
                                 "상추를 치료해줄 사람 어디 없나. 저만 매번 실패하나요..\n이번에는 꼭 성공해서 얼른 상추쌈 싸먹어봐요!"),
-                        MyFarmclubInfo(),
-                        SizedBox(
+                        const MyFarmclubInfo(),
+                        const SizedBox(
                           height: 8,
                         ),
-                        GroupRate(),
-                        SizedBox(
+                        const GroupRate(),
+                        const SizedBox(
                           height: 16,
                         ),
-                        Divider(
+                        const Divider(
                           thickness: 12,
                           color: FarmusThemeData.dividerBackground,
                         ),
-                        SizedBox(
+                        const SizedBox(
                           height: 12,
                         ),
-                        FarmclubTitleWithDivider(title: "함께 도전해요"),
+                        const FarmclubTitleWithDivider(title: "함께 도전해요"),
                         GestureDetector(
                           onTap: () {
                             Navigator.push(
                               context,
                               MaterialPageRoute(
                                 builder: (context) {
-                                  return FarmclubChallengeScreen();
+                                  return const FarmclubChallengeScreen();
                                 },
                               ),
                             );
                           },
-                          child: ChallengeStep(
+                          child: const ChallengeStep(
                             step: "0",
                             title: "준비물을 챙겨요",
                           ),
                         ),
-                        SizedBox(
+                        const SizedBox(
                           height: 16,
                         ),
                         GestureDetector(
@@ -138,16 +138,16 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                               context,
                               MaterialPageRoute(
                                 builder: (context) {
-                                  return FarmclubChallengeScreen();
+                                  return const FarmclubChallengeScreen();
                                 },
                               ),
                             );
                           },
-                          child: ChallengeHelp(
+                          child: const ChallengeHelp(
                             help: "상추 씨앗과 상토, 재배 용기를 준비해 주세요",
                           ),
                         ),
-                        SizedBox(
+                        const SizedBox(
                           height: 16,
                         ),
                         GestureDetector(
@@ -156,23 +156,23 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                                 context,
                                 MaterialPageRoute(
                                   builder: (context) {
-                                    return FarmclubChallengeScreen();
+                                    return const FarmclubChallengeScreen();
                                   },
                                 ),
                               );
                             },
-                            child: ChallengeFeed()),
-                        SizedBox(
+                            child: const ChallengeFeed()),
+                        const SizedBox(
                           height: 16,
                         ),
-                        Divider(
+                        const Divider(
                           thickness: 12,
                           color: FarmusThemeData.dividerBackground,
                         ),
-                        SizedBox(
+                        const SizedBox(
                           height: 12,
                         ),
-                        FarmclubTitleWithDivider(title: "함께 기록해요"),
+                        const FarmclubTitleWithDivider(title: "함께 기록해요"),
                         GestureDetector(
                           onTap: () {
                             Navigator.push(
@@ -184,12 +184,12 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                               ),
                             );
                           },
-                          child: RecordProfile(
+                          child: const RecordProfile(
                             nickname: "파머",
                             postTime: "10/29 4:12",
                           ),
                         ),
-                        SizedBox(
+                        const SizedBox(
                           height: 12,
                         ),
                         GestureDetector(
@@ -218,16 +218,16 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                               ),
                             );
                           },
-                          child: Padding(
-                            padding: const EdgeInsets.all(16.0),
+                          child: const Padding(
+                            padding: EdgeInsets.all(16.0),
                             child: Text(
                               "우리 상훈이가 쑥쑥 자라고 있네? 얼른 다 자라서 삼겹살이랑 쌈장 마늘 해서 상추쌈 싸먹고 싶다. 기대된다~~",
                               style: FarmusThemeData.darkStyle14,
                             ),
                           ),
                         ),
-                        SizedBox(
-                          height: 50,
+                        const SizedBox(
+                          height: 60,
                         ),
                       ],
                     ),
@@ -239,7 +239,7 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       floatingActionButton: widget.isFarmclub
           ? Container(
-              padding: EdgeInsets.symmetric(horizontal: 8),
+              padding: const EdgeInsets.all(8),
               color: Colors.transparent,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -254,7 +254,7 @@ class _FarmclubScreenState extends State<FarmclubScreen> {
                             context,
                             MaterialPageRoute(
                               builder: (context) {
-                                return MyFarmclubMissionScreen();
+                                return const MyFarmclubMissionScreen();
                               },
                             ),
                           );

--- a/lib/view/farmclub/farmclub_search_screen.dart
+++ b/lib/view/farmclub/farmclub_search_screen.dart
@@ -30,27 +30,30 @@ class _FarmclubSearchScreenState extends State<FarmclubSearchScreen> {
                 height: 16,
               ),
               Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  const Expanded(
+                  Expanded(
                     child: SearchEdit(),
                   ),
-                  GestureDetector(
-                    onTap: () {
-                      Navigator.pop(context);
-                    },
-                    child: Bouncing(
-                      onPress: () {
-                        Navigator.pop(context);
-                      },
-                      child: const Padding(
-                        padding: EdgeInsets.all(8.0),
+                  SizedBox(
+                    width: 8,
+                  ),
+                  Bouncing(
+                    onPress: () {},
+                    child: Padding(
+                      padding: EdgeInsets.all(8.0),
+                      child: GestureDetector(
+                        onTap: () {
+                          Navigator.pop(context);
+                        },
                         child: Text(
                           "취소",
                           style: FarmusThemeData.grey1Style14,
                         ),
                       ),
                     ),
-                  )
+                  ),
                 ],
               ),
               const SizedBox(

--- a/lib/view/my_page/component/my_page_header.dart
+++ b/lib/view/my_page/component/my_page_header.dart
@@ -8,6 +8,7 @@ class MyPageHeader extends StatelessWidget {
   final int? date;
   final String? imagePath;
 
+
   MyPageHeader({
     Key? key,
     required this.name,

--- a/lib/view/my_page/component/my_page_history.dart
+++ b/lib/view/my_page/component/my_page_history.dart
@@ -3,7 +3,7 @@ import 'package:mojacknong_android/common/farmus_theme_data.dart';
 
 // 새로운 페이지를 위한 스텁(더미) 위젯
 class MyPageList extends StatelessWidget {
-  final String data; // 데이터 전달 예제
+  final String? data; // 데이터 전달 예제
 
   const MyPageList({Key? key, required this.data}) : super(key: key);
 
@@ -11,7 +11,7 @@ class MyPageList extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(data), // AppBar에 데이터를 제목으로 사용
+        title: Text(data!), // AppBar에 데이터를 제목으로 사용
       ),
       body: Center(
         child: Text('New page with data: $data'),
@@ -21,15 +21,15 @@ class MyPageList extends StatelessWidget {
 }
 
 class MyPageHistory extends StatefulWidget {
-  final String name;
-  final String nickname;
-  final String date;
+  final String? name;
+  final String? veggieName;
+  final String? period;
 
   const MyPageHistory({
     Key? key,
     required this.name,
-    required this.nickname,
-    required this.date,
+    required this.veggieName,
+    required this.period,
   }) : super(key: key);
 
   @override
@@ -86,7 +86,7 @@ class _MyPageHistoryState extends State<MyPageHistory> {
                           ),
                         ),
                         TextSpan(
-                          text: widget.nickname,
+                          text: widget.veggieName,
                           style: const TextStyle(
                             fontSize: 13.0,
                           ),
@@ -96,7 +96,7 @@ class _MyPageHistoryState extends State<MyPageHistory> {
                   ),
                   const SizedBox(height: 12.0),
                   Text(
-                    widget.date,
+                    widget.period!,
                     style: const TextStyle(
                         color: FarmusThemeData.brownText // 색상 설정
                         ),

--- a/lib/view/my_page/component/my_page_history.dart
+++ b/lib/view/my_page/component/my_page_history.dart
@@ -24,12 +24,14 @@ class MyPageHistory extends StatefulWidget {
   final String? name;
   final String? veggieName;
   final String? period;
+  final String? image;
 
   const MyPageHistory({
     Key? key,
     required this.name,
     required this.veggieName,
     required this.period,
+    required this.image
   }) : super(key: key);
 
   @override
@@ -37,6 +39,8 @@ class MyPageHistory extends StatefulWidget {
 }
 
 class _MyPageHistoryState extends State<MyPageHistory> {
+
+
   void _navigateToNewPage(BuildContext context) {
     // `MaterialPageRoute`를 사용하여 새 페이지로 이동
     Navigator.of(context).push(MaterialPageRoute(
@@ -60,9 +64,10 @@ class _MyPageHistoryState extends State<MyPageHistory> {
               width: 64.0,
               height: 64.0,
               decoration: BoxDecoration(
-                image: const DecorationImage(
+                image: DecorationImage(
                   image: NetworkImage(
-                      'https://via.placeholder.com/150'), // 이미지 URL
+                      widget.image ?? ''
+                      ), // 이미지 URL
                   fit: BoxFit.cover, // 이미지가 컨테이너를 꽉 채우도록 설정
                 ),
                 borderRadius:

--- a/lib/view/my_page/history/my_farm_history.dart
+++ b/lib/view/my_page/history/my_farm_history.dart
@@ -3,6 +3,8 @@ import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_history.dart';
 
+import '../../../repository/mypage_repository.dart';
+
 class MyFarmClubHistory extends StatelessWidget {
   const MyFarmClubHistory({super.key});
 
@@ -11,32 +13,38 @@ class MyFarmClubHistory extends StatelessWidget {
     return Scaffold(
       appBar: PrimaryAppBar(title: "팜클럽 히스토리"),
       backgroundColor: FarmusThemeData.white,
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView(
-              padding: const EdgeInsets.only(top: 4.0),
-              children: const <Widget>[
-                MyPageHistory(
-                  name: '상추 좋아하세요',
-                  veggieName: '상추',
-                  period: '2023.10.01~2023.11.22',
-                ),
-                MyPageHistory(
-                  name: '남아프리카공화국',
-                  veggieName: '파프리카',
-                  period: '2023.06.27~현재',
-                ),
-                MyPageHistory(
-                  name: '깨르륵깨르륵',
-                  veggieName: '깻잎',
-                  period: '2023.05.03~현재',
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
+      body: FutureBuilder(
+          future: MypageRepository.getHistoryApi(),
+          builder: (context, snapshot) {
+
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              print("화면 로딩 중");
+              return CircularProgressIndicator();
+            } else if (snapshot.hasError) {
+              // 에러가 발생한 경우
+              return Text('Error: ${snapshot.error}');
+            } else {
+              // 데이터가 성공적으로 도착한 경우
+
+              final data = snapshot.data;
+
+              return ListView.builder(
+                padding: const EdgeInsets.only(top: 4.0),
+                itemCount: data?.farmClubHistoryDetailList.length ?? 0,
+                itemBuilder: (context, index) {
+                  final reversedIndex = data!.farmClubHistoryDetailList.length - index - 1;
+                  return MyPageHistory(
+                    name: data.farmClubHistoryDetailList[reversedIndex].name,
+                    veggieName: data.farmClubHistoryDetailList[reversedIndex].veggieName,
+                    period: data.farmClubHistoryDetailList[reversedIndex].period,
+                    image: data.farmClubHistoryDetailList[reversedIndex].image,
+                  );
+                },
+              );
+
+            }
+          }
+      )
     );
   }
 }

--- a/lib/view/my_page/history/my_farm_history.dart
+++ b/lib/view/my_page/history/my_farm_history.dart
@@ -19,18 +19,18 @@ class MyFarmClubHistory extends StatelessWidget {
               children: const <Widget>[
                 MyPageHistory(
                   name: '상추 좋아하세요',
-                  nickname: '상추',
-                  date: '2023.10.01~2023.11.22',
+                  veggieName: '상추',
+                  period: '2023.10.01~2023.11.22',
                 ),
                 MyPageHistory(
                   name: '남아프리카공화국',
-                  nickname: '파프리카',
-                  date: '2023.06.27~현재',
+                  veggieName: '파프리카',
+                  period: '2023.06.27~현재',
                 ),
                 MyPageHistory(
                   name: '깨르륵깨르륵',
-                  nickname: '깻잎',
-                  date: '2023.05.03~현재',
+                  veggieName: '깻잎',
+                  period: '2023.05.03~현재',
                 ),
               ],
             ),

--- a/lib/view/my_page/history/my_vege_history.dart
+++ b/lib/view/my_page/history/my_vege_history.dart
@@ -21,18 +21,18 @@ class MyVegeHistory extends StatelessWidget {
               children: const <Widget>[
                 MyPageHistory(
                   name: '상훈이',
-                  nickname: '상추',
-                  date: '2023.10.01~2023.11.22',
+                  veggieName: '상추',
+                  period: '2023.10.01~2023.11.22',
                 ),
                 MyPageHistory(
                   name: '먹쟁이토마토',
-                  nickname: '방울토마토',
-                  date: '2023.06.27~현재',
+                  veggieName: '방울토마토',
+                  period: '2023.06.27~현재',
                 ),
                 MyPageHistory(
                   name: '깨르륵',
-                  nickname: '깻잎',
-                  date: '2023.05.03~현재',
+                  veggieName: '깻잎',
+                  period: '2023.05.03~현재',
                 ),
               ],
             ),

--- a/lib/view/my_page/history/my_vege_history.dart
+++ b/lib/view/my_page/history/my_vege_history.dart
@@ -3,6 +3,10 @@ import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_history.dart';
 
+import '../../../model/mypage_history.dart';
+import '../../../repository/mypage_repository.dart';
+import '../component/my_page_header.dart';
+
 // 채소 히스토리 화면
 class MyVegeHistory extends StatelessWidget {
   const MyVegeHistory({super.key});
@@ -12,33 +16,37 @@ class MyVegeHistory extends StatelessWidget {
     return Scaffold(
       appBar: PrimaryAppBar(title: "채소 히스토리"),
       backgroundColor: FarmusThemeData.white,
-      body: Column(
-        children: [
-          const SizedBox(height: 0), // 상단 여백 추가
-          Expanded(
-            child: ListView(
-              padding: const EdgeInsets.only(top: 4.0),
-              children: const <Widget>[
-                MyPageHistory(
-                  name: '상훈이',
-                  veggieName: '상추',
-                  period: '2023.10.01~2023.11.22',
-                ),
-                MyPageHistory(
-                  name: '먹쟁이토마토',
-                  veggieName: '방울토마토',
-                  period: '2023.06.27~현재',
-                ),
-                MyPageHistory(
-                  name: '깨르륵',
-                  veggieName: '깻잎',
-                  period: '2023.05.03~현재',
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
+      body: FutureBuilder(
+          future: MypageRepository.getHistoryApi(),
+          builder: (context, snapshot) {
+
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              print("화면 로딩 중");
+              return CircularProgressIndicator();
+            } else if (snapshot.hasError) {
+              // 에러가 발생한 경우
+              return Text('Error: ${snapshot.error}');
+            } else {
+              // 데이터가 성공적으로 도착한 경우
+
+              final data = snapshot.data;
+
+              return ListView.builder(
+                padding: const EdgeInsets.only(top: 4.0),
+                itemCount: data?.veggieHistoryDetailList.length ?? 0,
+                itemBuilder: (context, index) {
+                  final reversedIndex = data!.veggieHistoryDetailList.length - index - 1;
+                  return MyPageHistory(
+                    name: data.veggieHistoryDetailList[reversedIndex].name,
+                    veggieName: data.veggieHistoryDetailList[reversedIndex].veggieName,
+                    period: data.veggieHistoryDetailList[reversedIndex].period,
+                    image: data.veggieHistoryDetailList[reversedIndex].image,
+                  );
+                },
+              );
+            }
+          }
+      )
     );
   }
 }

--- a/lib/view/my_page/my_page_screen.dart
+++ b/lib/view/my_page/my_page_screen.dart
@@ -5,6 +5,8 @@ import 'package:mojacknong_android/view/my_page/component/my_history_header.dart
 import 'package:mojacknong_android/view/my_page/component/my_page_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_history.dart';
 
+import '../../model/farmus_user.dart';
+import '../../model/mypage_history.dart';
 import '../../repository/mypage_repository.dart';
 
 class MyPageScreen extends StatefulWidget {
@@ -18,7 +20,7 @@ class _MyPageScreenState extends State<MyPageScreen> {
     return Scaffold(
         backgroundColor: FarmusThemeData.white,
         body: FutureBuilder(
-            future: MypageRepository.getUserApi(),
+            future: MypageRepository.getMyPageData(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 print("화면 로딩 중");
@@ -28,130 +30,80 @@ class _MyPageScreenState extends State<MyPageScreen> {
                 return Text('Error: ${snapshot.error}');
               } else {
                 // 데이터가 성공적으로 도착한 경우
-                final data = snapshot.data;
-                print(data);
+            //    final data = snapshot.data;
+                final List<dynamic> data = snapshot.data as List<dynamic>;
+                final FarmusUser? user = data[0] as FarmusUser?;
+                final MypageHistory? history = data[1] as MypageHistory?;
+
+                print(history?.veggieHistoryDetailList[0].image);
+                print(history?.farmClubHistoryDetailList[0].period);
+
+
                 return Column(children: <Widget>[
                   MyPageHeader(
-                      name: data?.nickName,
-                      date: data?.dday,
-                      imagePath: data?.userImageUrl), // 사용자 정의 헤더를 여기에 넣습니다.
+                      name: user?.nickName,
+                      date: user?.dday,
+                      imagePath: user?.userImageUrl
+                  ), // 사용자 정의 헤더를 여기에 넣습니다.
                   const SizedBox(height: 12.0), // 필요한 공간을 추가합니다.
 
                   HistoryHeader(historyType: "채소 히스토리"),
                   const SizedBox(height: 12.0),
                   Expanded(
-                    child: ListView(
+                      child: ListView.builder(
                       padding: const EdgeInsets.only(top: 4.0),
-                      children: const <Widget>[
-                        MyPageHistory(
-                          name: '상훈이',
-                          nickname: '상추',
-                          date: '2023.10.01~2023.11.22',
-                        ),
-                        MyPageHistory(
-                          name: '먹쟁이토마토',
-                          nickname: '방울토마토',
-                          date: '2023.06.27~현재',
-                        ),
-                        MyPageHistory(
-                          name: '깨르륵',
-                          nickname: '깻잎',
-                          date: '2023.05.03~현재',
-                        ),
-                        // 추가하려면 여기에 넣기
-                      ],
-                    ),
-                  ),
+                      itemCount: history?.veggieHistoryDetailList.length,
+                      itemBuilder: (context, index) {
+                        return MyPageHistory(
+                        name: history?.veggieHistoryDetailList[index].name,
+                        veggieName: history?.veggieHistoryDetailList[index].veggieName,
+                        period: history?.veggieHistoryDetailList[index].period,
+                        );
+                     },
+                   ),
+                ),
+
                   const SizedBox(height: 10.0),
                   const ChallengeHeader(historyType: "팜클럽 히스토리"),
                   const SizedBox(height: 12.0),
                   Expanded(
-                      child: ListView(
-                    padding: const EdgeInsets.only(top: 4.0),
-                    children: const <Widget>[
-                      MyPageHistory(
-                        name: '상추 좋아하세요',
-                        nickname: '상추',
-                        date: '2023.10.01~2023.11.22',
+                      child: ListView.builder(
+                      padding: const EdgeInsets.only(top: 4.0),
+                      itemCount: history?.farmClubHistoryDetailList.length,
+                      itemBuilder: (context, index) {
+                        return MyPageHistory(
+                        name: history?.farmClubHistoryDetailList[index].name,
+                        veggieName: history?.farmClubHistoryDetailList[index].veggieName,
+                        period: history?.farmClubHistoryDetailList[index].period,
+                    );
+                      },
                       ),
-                      MyPageHistory(
-                        name: '남아프리카공화국',
-                        nickname: '파프리카',
-                        date: '2023.06.27~현재',
-                      ),
-                      MyPageHistory(
-                        name: '깨르륵깨르륵',
-                        nickname: '깻잎',
-                        date: '2023.05.03~현재',
-                      ),
-                      // 추가하려면 여기에 넣기
-                    ],
-                  ))
+                          )
+
                 ]);
               }
             }));
   }
+
+
 }
 
-    //
-    //   Column(
-    //     children: <Widget>[
-    //       const MyPageHeader(name: '파머', date: '100'), // 사용자 정의 헤더를 여기에 넣습니다.
-    //       const SizedBox(height: 12.0), // 필요한 공간을 추가합니다.
-    //
-    //       const HistoryHeader(historyType: "채소 히스토리"),
-    //       const SizedBox(height: 12.0),
-    //       Expanded(
-    //         child: ListView(
-    //           padding: const EdgeInsets.only(top: 4.0),
-    //           children: const <Widget>[
-    //             MyPageHistory(
-    //               name: '상훈이',
-    //               nickname: '상추',
-    //               date: '2023.10.01~2023.11.22',
-    //             ),
-    //             MyPageHistory(
-    //               name: '먹쟁이토마토',
-    //               nickname: '방울토마토',
-    //               date: '2023.06.27~현재',
-    //             ),
-    //             MyPageHistory(
-    //               name: '깨르륵',
-    //               nickname: '깻잎',
-    //               date: '2023.05.03~현재',
-    //             ),
-    //             // 추가하려면 여기에 넣기
-    //           ],
-    //         ),
-    //       ),
-    //       const SizedBox(height: 10.0),
-    //       const ChallengeHeader(historyType: "팜클럽 히스토리"),
-    //       const SizedBox(height: 12.0),
-    //       Expanded(
-    //         child: ListView(
-    //           padding: const EdgeInsets.only(top: 4.0),
-    //           children: const <Widget>[
-    //             MyPageHistory(
-    //               name: '상추 좋아하세요',
-    //               nickname: '상추',
-    //               date: '2023.10.01~2023.11.22',
-    //             ),
-    //             MyPageHistory(
-    //               name: '남아프리카공화국',
-    //               nickname: '파프리카',
-    //               date: '2023.06.27~현재',
-    //             ),
-    //             MyPageHistory(
-    //               name: '깨르륵깨르륵',
-    //               nickname: '깻잎',
-    //               date: '2023.05.03~현재',
-    //             ),
-    //             // 추가하려면 여기에 넣기
-    //           ],
-    //         ),
-    //       ),
-    //     ],
-    //   ),
-    // );
-    //
-    //
+
+// children: const <Widget>[
+//   MyPageHistory(
+//     name: '상훈이',
+//     nickname: '상추',
+//     date: '2023.10.01~2023.11.22',
+//   ),
+//   MyPageHistory(
+//     name: '먹쟁이토마토',
+//     nickname: '방울토마토',
+//     date: '2023.06.27~현재',
+//   ),
+//   MyPageHistory(
+//     name: '깨르륵',
+//     nickname: '깻잎',
+//     date: '2023.05.03~현재',
+//   ),
+//   // 추가하려면 여기에 넣기
+// ],

--- a/lib/view/my_page/my_page_screen.dart
+++ b/lib/view/my_page/my_page_screen.dart
@@ -1,10 +1,12 @@
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view/my_page/component/my_challenge_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_history_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_history.dart';
-
 import '../../model/farmus_user.dart';
 import '../../model/mypage_history.dart';
 import '../../repository/mypage_repository.dart';
@@ -30,13 +32,10 @@ class _MyPageScreenState extends State<MyPageScreen> {
                 return Text('Error: ${snapshot.error}');
               } else {
                 // 데이터가 성공적으로 도착한 경우
-            //    final data = snapshot.data;
+            //  final data = snapshot.data;
                 final List<dynamic> data = snapshot.data as List<dynamic>;
                 final FarmusUser? user = data[0] as FarmusUser?;
                 final MypageHistory? history = data[1] as MypageHistory?;
-
-                print(history?.veggieHistoryDetailList[0].image);
-                print(history?.farmClubHistoryDetailList[0].period);
 
 
                 return Column(children: <Widget>[
@@ -50,60 +49,72 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   HistoryHeader(historyType: "채소 히스토리"),
                   const SizedBox(height: 12.0),
                   Expanded(
-                      child: ListView.builder(
+                    child: history?.veggieHistoryDetailList != null
+                        ? ListView.builder(
                       padding: const EdgeInsets.only(top: 4.0),
-                      itemCount: history?.veggieHistoryDetailList.length,
+                      itemCount: min(3, history!.veggieHistoryDetailList.length),
                       itemBuilder: (context, index) {
+                        final reversedIndex = history.veggieHistoryDetailList.length - index - 1;
                         return MyPageHistory(
-                        name: history?.veggieHistoryDetailList[index].name,
-                        veggieName: history?.veggieHistoryDetailList[index].veggieName,
-                        period: history?.veggieHistoryDetailList[index].period,
+                          name: history.veggieHistoryDetailList[reversedIndex].name,
+                          veggieName: history.veggieHistoryDetailList[reversedIndex].veggieName,
+                          period: history.veggieHistoryDetailList[reversedIndex].period,
+                          image: history.veggieHistoryDetailList[reversedIndex].image,
                         );
-                     },
-                   ),
-                ),
+                      },
+                    )
+                        : noData(),
+                  ),
+
+
 
                   const SizedBox(height: 10.0),
-                  const ChallengeHeader(historyType: "팜클럽 히스토리"),
+                  ChallengeHeader(historyType: "팜클럽 히스토리"),
                   const SizedBox(height: 12.0),
                   Expanded(
-                      child: ListView.builder(
+                    child: history?.farmClubHistoryDetailList != null
+                        ? ListView.builder(
                       padding: const EdgeInsets.only(top: 4.0),
-                      itemCount: history?.farmClubHistoryDetailList.length,
+                      itemCount: min(3, history!.farmClubHistoryDetailList.length),
                       itemBuilder: (context, index) {
+                        print(22);
+                        final reversedIndex = history.farmClubHistoryDetailList.length - index - 1;
                         return MyPageHistory(
-                        name: history?.farmClubHistoryDetailList[index].name,
-                        veggieName: history?.farmClubHistoryDetailList[index].veggieName,
-                        period: history?.farmClubHistoryDetailList[index].period,
-                    );
+                          name: history.farmClubHistoryDetailList[reversedIndex].name,
+                          veggieName: history.farmClubHistoryDetailList[reversedIndex].veggieName,
+                          period: history.farmClubHistoryDetailList[reversedIndex].period,
+                          image: history.farmClubHistoryDetailList[reversedIndex].image,
+                        );
                       },
-                      ),
-                          )
+                    )
+                        : noData(),
+                  ),
+
 
                 ]);
               }
-            }));
+            }
+            )
+    );
+  }
+
+  bool isCheckNull(List<dynamic>? list){
+    if(list!.isEmpty){
+
+      return true;
+
+    }
+    return false;
+  }
+
+  Center noData(){
+    return const Center(
+      child: Text("히스토리가 없습니다.")
+    );
   }
 
 
+
+
+
 }
-
-
-// children: const <Widget>[
-//   MyPageHistory(
-//     name: '상훈이',
-//     nickname: '상추',
-//     date: '2023.10.01~2023.11.22',
-//   ),
-//   MyPageHistory(
-//     name: '먹쟁이토마토',
-//     nickname: '방울토마토',
-//     date: '2023.06.27~현재',
-//   ),
-//   MyPageHistory(
-//     name: '깨르륵',
-//     nickname: '깻잎',
-//     date: '2023.05.03~현재',
-//   ),
-//   // 추가하려면 여기에 넣기
-// ],

--- a/lib/view_model/controllers/bottom_sheet_controller.dart
+++ b/lib/view_model/controllers/bottom_sheet_controller.dart
@@ -95,6 +95,20 @@ class BottomSheetController extends GetxController {
       builder: (BuildContext context) {
         return DialogJoinFarmclub(
           title: title,
+          content: "팜클럽에 가입했어요",
+        );
+      },
+    );
+  }
+
+  void showAuthDialog(BuildContext context, String title, String content) {
+    showDialog<void>(
+      context: context,
+      barrierColor: FarmusThemeData.grey2,
+      builder: (BuildContext context) {
+        return DialogJoinFarmclub(
+          title: title,
+          content: content,
         );
       },
     );

--- a/lib/view_model/controllers/bottom_sheet_controller.dart
+++ b/lib/view_model/controllers/bottom_sheet_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:mojacknong_android/common/bottom_sheet/bottom_sheet_farmclub_exit.dart';
 import 'package:mojacknong_android/common/bottom_sheet/bottom_sheet_farmclub_join.dart';
 import 'package:mojacknong_android/common/dialog/Dialog_join_farmclub.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
@@ -73,6 +74,16 @@ class BottomSheetController extends GetxController {
         return BottomSheetFarmclubJoin(
           title: title,
         );
+      },
+    );
+  }
+
+  void showFarmclubExitBottomSheet(BuildContext context, String title) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: FarmusThemeData.white,
+      builder: (BuildContext context) {
+        return BottomSheetFarmclubExit();
       },
     );
   }

--- a/lib/view_model/controllers/farmclub_controller.dart
+++ b/lib/view_model/controllers/farmclub_controller.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -17,9 +19,14 @@ class FarmclubController extends GetxController {
 
   RxInt selectedTextBoxIndex = RxInt(0);
 
+  final contentValue = "".obs;
+  final image = Rxn<File>();
+  final isFormVaild = RxBool(false);
+
   @override
   void onInit() {
     super.onInit();
+
     controller.addListener(() {
       final value = controller.text;
       // 텍스트 필드에 값이 입력 되었는지 여부
@@ -29,6 +36,24 @@ class FarmclubController extends GetxController {
         hasInput.value = false;
       }
     });
+
+    ever(contentValue, (_) {
+      checkFormVaildity();
+    });
+
+    ever(image, (_) => checkFormVaildity());
+  }
+
+  void updateContentValue(String value) {
+    contentValue.value = value;
+  }
+
+  void setImageFile(File file) {
+    image.value = file;
+  }
+
+  void checkFormVaildity() {
+    isFormVaild.value = contentValue.isNotEmpty && image.value != null;
   }
 
   void toggleSelectCheck() {

--- a/lib/view_model/controllers/farmclub_controller.dart
+++ b/lib/view_model/controllers/farmclub_controller.dart
@@ -9,7 +9,13 @@ class FarmclubController extends GetxController {
   RxBool isSelectLike = RxBool(false);
   RxInt like = 2.obs; // 초기 좋아요 수
 
-  RxBool isCheck = RxBool(false); // 추가
+  RxBool isCheck = RxBool(false);
+  RxBool shouldExit = RxBool(false);
+
+  RxBool isTextBox1Selected = RxBool(false);
+  RxBool isTextBox2Selected = RxBool(false);
+
+  RxInt selectedTextBoxIndex = RxInt(0);
 
   @override
   void onInit() {
@@ -27,5 +33,25 @@ class FarmclubController extends GetxController {
 
   void toggleSelectCheck() {
     isCheck.value = !isCheck.value;
+  }
+
+  void toggleSelectTextBox(int index) {
+    // 이미 선택된 텍스트 박스를 다시 선택하는 경우 무시
+    if (index == selectedTextBoxIndex.value) return;
+
+    // 선택된 텍스트 박스의 인덱스 갱신
+    selectedTextBoxIndex.value = index;
+
+    // 선택된 텍스트 박스에 따라 shouldExit 및 배경 색상 업데이트
+    toggleShouldExit();
+  }
+
+  // shouldExit 값 및 배경 색상을 업데이트하는 메서드
+  void toggleShouldExit() {
+    shouldExit.value = isCheck.value;
+
+    // 선택된 텍스트 박스에 따라 배경 색상 업데이트
+    isTextBox1Selected.value = selectedTextBoxIndex.value == 0;
+    isTextBox2Selected.value = selectedTextBoxIndex.value == 1;
   }
 }


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #52 


### 🍠 Summary
팜클럽 나가기 바텀 시트 구현 완료했습니다.
도움말 버튼 클릭시 도움말 화면이 나타납니다.
"더보기"를 클릭했을 때 미션 피드가 나타납니다.
미션 인증하기 버튼을 클릭했을 때, 미션 인증 페이지로 넘어가고, 사진과 글을 모두 등록했을 때 업로드 가능합니다.
바운싱 효과를 약하게 변경했습니다



### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
