### PR TITLE
[Feat] : 팜클럽 개설하기 화면, 마이페이지 로그아웃 화면 구현

### DIFF
--- a/lib/common/bottom_sheet/bottom_sheet_farmclub_join.dart
+++ b/lib/common/bottom_sheet/bottom_sheet_farmclub_join.dart
@@ -61,7 +61,9 @@ class _BottomSheetFarmclubJoinState extends State<BottomSheetFarmclubJoin> {
             ),
             child: Column(
               children: [
-                VegetableList(),
+                VegetableList(
+                  isMake: false,
+                ),
               ],
             ),
           ),

--- a/lib/common/bottom_sheet/cupertino_action_sheet_helper.dart
+++ b/lib/common/bottom_sheet/cupertino_action_sheet_helper.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/cupertino.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+
+class CupertinoActionSheetHelper {
+  static void showActionSheetComment(
+    BuildContext? context, {
+    required String message,
+    required String cancelText,
+    required String confirmText,
+  }) {
+    showCupertinoModalPopup<void>(
+      context: context!,
+      builder: (BuildContext context) => CupertinoActionSheet(
+        message: Text(
+          message,
+          style: const TextStyle(
+            color: FarmusThemeData.grey2,
+            fontSize: 12,
+            fontFamily: "Pretendard",
+          ),
+        ),
+        actions: <CupertinoActionSheetAction>[
+          CupertinoActionSheetAction(
+            isDestructiveAction: true,
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: Text(
+              cancelText,
+              style: const TextStyle(
+                color: FarmusThemeData.dark,
+                fontSize: 14,
+                fontFamily: "Pretendard",
+              ),
+            ),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: Text(
+              confirmText,
+              style: const TextStyle(
+                color: FarmusThemeData.dark,
+                fontSize: 14,
+                fontFamily: "Pretendard",
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void showActionSheetRedMessage(
+    BuildContext? context, {
+    required String message,
+    required String cancelText,
+    required String confirmText,
+  }) {
+    showCupertinoModalPopup<void>(
+      context: context!,
+      builder: (BuildContext context) => CupertinoActionSheet(
+        message: Text(
+          message,
+          style: const TextStyle(
+            color: FarmusThemeData.grey2,
+            fontSize: 12,
+            fontFamily: "Pretendard",
+          ),
+        ),
+        actions: <CupertinoActionSheetAction>[
+          CupertinoActionSheetAction(
+            isDestructiveAction: true,
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: Text(
+              confirmText,
+              style: const TextStyle(
+                color: FarmusThemeData.red,
+                fontSize: 14,
+                fontFamily: "Pretendard",
+              ),
+            ),
+          ),
+          CupertinoActionSheetAction(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: Text(
+              cancelText,
+              style: const TextStyle(
+                color: FarmusThemeData.dark,
+                fontSize: 14,
+                fontFamily: "Pretendard",
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void showCustomCupertinoActionSheet(
+    BuildContext context, {
+    String? title,
+    required String message,
+    required List<String> options,
+    required String cancelButtonText,
+  }) {
+    showCupertinoModalPopup<void>(
+      context: context,
+      builder: (BuildContext context) => CupertinoActionSheet(
+        title: title != null ? Text(title) : null,
+        message: Text(
+          message,
+          style: const TextStyle(
+            color: FarmusThemeData.grey2,
+            fontSize: 12,
+            fontFamily: "Pretendard",
+          ),
+        ),
+        actions: List.generate(
+          options.length,
+          (index) => CupertinoActionSheetAction(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: Text(
+              options[index],
+              style: const TextStyle(
+                color: FarmusThemeData.dark,
+                fontSize: 14,
+                fontFamily: "Pretendard",
+              ),
+            ),
+          ),
+        ),
+        cancelButton: CupertinoActionSheetAction(
+          onPressed: () {
+            Navigator.pop(context);
+          },
+          child: Text(
+            cancelButtonText,
+            style: const TextStyle(
+              color: FarmusThemeData.dark,
+              fontSize: 14,
+              fontFamily: "Pretendard",
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:kakao_flutter_sdk/kakao_flutter_sdk_template.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/firebase_options.dart';
-import 'package:mojacknong_android/view/main/main_screen.dart';
+import 'package:mojacknong_android/view/login/login_screen.dart';
 
 Future<void> main() async {
   // 웹 환경에서 카카오 로그인을 정상적으로 완료하기 위함
@@ -20,10 +20,12 @@ Future<void> main() async {
     javaScriptAppKey: '7f2a1972870b2cadb2a0506a7e309020',
   );
 
+  WidgetsFlutterBinding.ensureInitialized();
+
   runApp(
     MaterialApp(
       title: "Farmus",
-      home: const MainScreen(),
+      home: const LoginScreen(),
       debugShowCheckedModeBanner: false,
       theme: ThemeData(fontFamily: 'Pretendard'),
     ),

--- a/lib/view/farmclub/component/around/vegetable_list.dart
+++ b/lib/view/farmclub/component/around/vegetable_list.dart
@@ -4,7 +4,9 @@ import 'package:get/get.dart';
 import 'package:mojacknong_android/view_model/controllers/farmclub_controller.dart';
 
 class VegetableList extends StatefulWidget {
-  const VegetableList({Key? key});
+  final bool isMake;
+
+  const VegetableList({Key? key, required this.isMake});
 
   @override
   State<VegetableList> createState() => _VegetableListState();
@@ -34,7 +36,7 @@ class _VegetableListState extends State<VegetableList> {
           SizedBox(
             width: 8,
           ),
-          Text("상훈이"),
+          widget.isMake ? Text("[상추] 상훈이") : Text("상훈이"),
         ],
       ),
     );

--- a/lib/view/farmclub/component/explore/green_button.dart
+++ b/lib/view/farmclub/component/explore/green_button.dart
@@ -1,25 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/bottom_sheet_controller.dart';
 
-class GreenButton extends StatelessWidget {
-  const GreenButton({super.key});
+class GreenButton extends StatefulWidget {
+  final String title;
+
+  const GreenButton({super.key, required this.title});
+
+  @override
+  State<GreenButton> createState() => _GreenButtonState();
+}
+
+class _GreenButtonState extends State<GreenButton> {
+  BottomSheetController controller = BottomSheetController();
 
   @override
   Widget build(BuildContext context) {
     return Bouncing(
       onPress: () {},
-      child: Container(
-        width: 45,
-        height: 30,
-        decoration: BoxDecoration(
-          color: FarmusThemeData.greenLight,
-          borderRadius: BorderRadius.circular(4),
-        ),
-        child: Center(
-          child: Text(
-            "참여",
-            style: FarmusThemeData.green1Style14,
+      child: GestureDetector(
+        onTap: () {
+          controller.showFarmclubJoinBottomSheet(context, widget.title);
+        },
+        child: Container(
+          width: 45,
+          height: 30,
+          decoration: BoxDecoration(
+            color: FarmusThemeData.greenLight,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Center(
+            child: Text(
+              "참여",
+              style: FarmusThemeData.green1Style14,
+            ),
           ),
         ),
       ),

--- a/lib/view/farmclub/component/farmclub.dart
+++ b/lib/view/farmclub/component/farmclub.dart
@@ -57,7 +57,9 @@ class _FarmclubState extends State<Farmclub> {
                 isRecommend: false,
               ),
               Spacer(),
-              GreenButton(),
+              GreenButton(
+                title: widget.title,
+              ),
             ],
           ),
         ),

--- a/lib/view/farmclub/component/farmclub_make_content.dart
+++ b/lib/view/farmclub/component/farmclub_make_content.dart
@@ -3,29 +3,29 @@ import 'package:get/get.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view_model/controllers/farmclub_make_controller.dart';
 
-class FarmclubMakeEdit extends StatefulWidget {
+class FarmclubMakeContent extends StatefulWidget {
   final String hintText;
 
-  const FarmclubMakeEdit({
+  const FarmclubMakeContent({
     Key? key,
     required this.hintText,
   }) : super(key: key);
 
   @override
-  State<FarmclubMakeEdit> createState() => _FarmclubMakeEditState();
+  State<FarmclubMakeContent> createState() => _FarmclubMakeContentState();
 }
 
-class _FarmclubMakeEditState extends State<FarmclubMakeEdit> {
+class _FarmclubMakeContentState extends State<FarmclubMakeContent> {
   FarmclubMakeController _controller = Get.put(FarmclubMakeController());
   final int maxLength = 20;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-      controller: _controller.nameController, // 사용할 컨트롤러 연결
-      maxLength: 20, // 최대 입력 글자수
+      controller: _controller.introController, // 사용할 컨트롤러 연결
+      maxLength: 50, // 최대 입력 글자수
       cursorColor: FarmusThemeData.grey2,
-      onChanged: _controller.updateTitleValue,
+      onChanged: _controller.updateContentValue,
 
       style: FarmusThemeData.darkStyle16,
       decoration: InputDecoration(
@@ -39,7 +39,7 @@ class _FarmclubMakeEditState extends State<FarmclubMakeEdit> {
         ),
         suffix: Obx(
           () => Text(
-            "${_controller.contentValue.value.length} / 20",
+            "${_controller.contentValue.value.length} / 50",
             style: TextStyle(
               color: FarmusThemeData.dark.withOpacity(0.3),
             ),

--- a/lib/view/farmclub/component/farmclub_make_edit.dart
+++ b/lib/view/farmclub/component/farmclub_make_edit.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_make_controller.dart';
+
+class FarmclubMakeEdit extends StatefulWidget {
+  const FarmclubMakeEdit({Key? key}) : super(key: key);
+
+  @override
+  State<FarmclubMakeEdit> createState() => _FarmclubMakeEditState();
+}
+
+class _FarmclubMakeEditState extends State<FarmclubMakeEdit> {
+  FarmclubMakeController _controller = Get.put(FarmclubMakeController());
+  final int maxLength = 20;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: _controller.controller, // 사용할 컨트롤러 연결
+      maxLength: 20, // 최대 입력 글자수
+      cursorColor: FarmusThemeData.grey2,
+      onChanged: _controller.updateContentValue,
+
+      style: FarmusThemeData.darkStyle16,
+      decoration: InputDecoration(
+        counterText: "", // 빈 문자열로 지정하여 기본 길이 표시를 비활성화
+        hintText: "클럽명 예시",
+        hintStyle: const TextStyle(
+          color: FarmusThemeData.grey3,
+          fontWeight: FontWeight.w400,
+          fontSize: 14,
+          fontFamily: "Pretendard",
+        ),
+        suffix: Obx(
+          () => Text(
+            "${_controller.contentValue.value.length} / 20",
+            style: TextStyle(
+              color: FarmusThemeData.dark.withOpacity(0.3),
+            ),
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(
+            color: FarmusThemeData.grey4,
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(8),
+          borderSide: const BorderSide(
+            color: FarmusThemeData.grey4,
+          ),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          vertical: 16.0,
+          horizontal: 16.0,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/farmclub/component/farmclub_make_member.dart
+++ b/lib/view/farmclub/component/farmclub_make_member.dart
@@ -3,29 +3,29 @@ import 'package:get/get.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view_model/controllers/farmclub_make_controller.dart';
 
-class FarmclubMakeEdit extends StatefulWidget {
+class FarmclubMakeMember extends StatefulWidget {
   final String hintText;
 
-  const FarmclubMakeEdit({
+  const FarmclubMakeMember({
     Key? key,
     required this.hintText,
   }) : super(key: key);
 
   @override
-  State<FarmclubMakeEdit> createState() => _FarmclubMakeEditState();
+  State<FarmclubMakeMember> createState() => _FarmclubMakeMemberState();
 }
 
-class _FarmclubMakeEditState extends State<FarmclubMakeEdit> {
+class _FarmclubMakeMemberState extends State<FarmclubMakeMember> {
   FarmclubMakeController _controller = Get.put(FarmclubMakeController());
-  final int maxLength = 20;
+  final int maxLength = 2;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-      controller: _controller.controller, // 사용할 컨트롤러 연결
-      maxLength: 20, // 최대 입력 글자수
+      controller: _controller.memberController, // 사용할 컨트롤러 연결
+      maxLength: 2, // 최대 입력 글자수
       cursorColor: FarmusThemeData.grey2,
-      onChanged: _controller.updateContentValue,
+      onChanged: _controller.updateMemberValue,
 
       style: FarmusThemeData.darkStyle16,
       decoration: InputDecoration(
@@ -37,14 +37,7 @@ class _FarmclubMakeEditState extends State<FarmclubMakeEdit> {
           fontSize: 14,
           fontFamily: "Pretendard",
         ),
-        suffix: Obx(
-          () => Text(
-            "${_controller.contentValue.value.length} / 20",
-            style: TextStyle(
-              color: FarmusThemeData.dark.withOpacity(0.3),
-            ),
-          ),
-        ),
+
         enabledBorder: OutlineInputBorder(
           borderRadius: BorderRadius.circular(8),
           borderSide: const BorderSide(

--- a/lib/view/farmclub/component/floating_button_farmclub.dart
+++ b/lib/view/farmclub/component/floating_button_farmclub.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_make_screen.dart';
 
 class FloatingButtonFarmclub extends StatelessWidget {
   const FloatingButtonFarmclub({Key? key}) : super(key: key);
@@ -14,7 +15,11 @@ class FloatingButtonFarmclub extends StatelessWidget {
         width: 75,
         height: 45,
         child: OutlinedButton(
-          onPressed: () {},
+          onPressed: () {
+            Navigator.push(context, MaterialPageRoute(builder: (context) {
+              return FarmclubMakeScreen();
+            }));
+          },
           style: ButtonStyle(
             backgroundColor: MaterialStateProperty.all<Color>(
               FarmusThemeData.brownButton,

--- a/lib/view/farmclub/component/my_farmclub.dart
+++ b/lib/view/farmclub/component/my_farmclub.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view/farmclub/farmclub_make_screen.dart';
 
 class MyFarmclub extends StatefulWidget {
   final bool isLast;
@@ -20,24 +21,38 @@ class _MyFarmclubState extends State<MyFarmclub> {
       onPress: () {},
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: Container(
-          width: 48,
-          height: 48,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
-            color: FarmusThemeData.brown3,
+        child: GestureDetector(
+          onTap: () {
+            widget.isLast == true
+                ? Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return FarmclubMakeScreen();
+                      },
+                    ),
+                  )
+                : null;
+          },
+          child: Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              color: FarmusThemeData.brown3,
+            ),
+            child: widget.isLast
+                ? Padding(
+                    padding: const EdgeInsets.all(14.0),
+                    child: SvgPicture.asset(
+                      "assets/image/ic_plus.svg",
+                      color: FarmusThemeData.brownText,
+                    ))
+                : Image.asset(
+                    widget.myFarmclubImage!,
+                    fit: BoxFit.fill,
+                  ),
           ),
-          child: widget.isLast
-              ? Padding(
-                  padding: const EdgeInsets.all(14.0),
-                  child: SvgPicture.asset(
-                    "assets/image/ic_plus.svg",
-                    color: FarmusThemeData.brownText,
-                  ))
-              : Image.asset(
-                  widget.myFarmclubImage!,
-                  fit: BoxFit.fill,
-                ),
         ),
       ),
     );

--- a/lib/view/farmclub/component/new_vegetable_item.dart
+++ b/lib/view/farmclub/component/new_vegetable_item.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+
+class NewVegetableItem extends StatefulWidget {
+  final String blackPath;
+  final String colPath;
+  final bool isSelected;
+  final Function onTap;
+  final String veggieName;
+  final String difficulty;
+
+  const NewVegetableItem({
+    Key? key,
+    required this.blackPath,
+    required this.colPath,
+    required this.isSelected,
+    required this.onTap,
+    required this.veggieName,
+    required this.difficulty,
+  }) : super(key: key);
+
+  @override
+  State<NewVegetableItem> createState() => _NewVegetableItemState();
+}
+
+class _NewVegetableItemState extends State<NewVegetableItem> {
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => widget.onTap(),
+      child: Column(
+        children: [
+          Expanded(
+            child: Container(
+              decoration: BoxDecoration(
+                border: Border.all(
+                    color: widget.isSelected
+                        ? FarmusThemeData.green1
+                        : FarmusThemeData.pictureBackground),
+                borderRadius: BorderRadius.circular(8),
+                color: FarmusThemeData.pictureBackground,
+              ),
+              child: Container(
+                height: 150,
+                alignment: Alignment.center,
+                child: widget.isSelected
+                    ? SvgPicture.asset(widget.colPath)
+                    : SvgPicture.asset(widget.blackPath),
+              ),
+            ),
+          ),
+          SizedBox(
+            height: 8,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                '${widget.veggieName}',
+                style: FarmusThemeData.darkStyle13,
+              ),
+              SizedBox(width: 8),
+              SvgPicture.asset("assets/image/line_vertical_grey1.svg"),
+              SizedBox(width: 8),
+              Text(
+                '${widget.difficulty}',
+                style: FarmusThemeData.darkStyle13,
+              ),
+            ],
+          ),
+          SizedBox(
+            height: 8,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/farmclub/component/new_vegetable_item.dart
+++ b/lib/view/farmclub/component/new_vegetable_item.dart
@@ -42,11 +42,16 @@ class _NewVegetableItemState extends State<NewVegetableItem> {
                 color: FarmusThemeData.pictureBackground,
               ),
               child: Container(
-                height: 150,
                 alignment: Alignment.center,
                 child: widget.isSelected
-                    ? SvgPicture.asset(widget.colPath)
-                    : SvgPicture.asset(widget.blackPath),
+                    ? SvgPicture.asset(
+                        widget.colPath,
+                        width: 80,
+                      )
+                    : SvgPicture.asset(
+                        widget.blackPath,
+                        width: 80,
+                      ),
               ),
             ),
           ),

--- a/lib/view/farmclub/component/new_vegetable_item.dart
+++ b/lib/view/farmclub/component/new_vegetable_item.dart
@@ -28,7 +28,9 @@ class _NewVegetableItemState extends State<NewVegetableItem> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: () => widget.onTap(),
+      onTap: () {
+        widget.onTap();
+      },
       child: Column(
         children: [
           Expanded(

--- a/lib/view/farmclub/component/new_vegetable_select.dart
+++ b/lib/view/farmclub/component/new_vegetable_select.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mojacknong_android/view/farmclub/component/new_vegetable_item.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_make_controller.dart';
+
+class NewVegetableSelect extends StatelessWidget {
+  final FarmclubMakeController farmclubMakeController =
+      Get.put(FarmclubMakeController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 300,
+      child: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2, crossAxisSpacing: 8),
+        itemCount: 6,
+        itemBuilder: (BuildContext context, int index) {
+          final veggieKey =
+              farmclubMakeController.veggieData.keys.elementAt(index);
+          final veggieName = farmclubMakeController.veggieData[veggieKey];
+          final veggieLevel = farmclubMakeController.veggieLevel[veggieKey];
+
+          return GetBuilder<FarmclubMakeController>(
+            builder: (controller) {
+              return SizedBox(
+                height: 180, // 아이템의 높이를 조절
+                child: NewVegetableItem(
+                  blackPath: 'assets/image/${veggieKey}_black.svg',
+                  colPath: 'assets/image/${veggieKey}_col.svg',
+                  isSelected: controller.isSelectedList[index],
+                  onTap: () => controller.toggleImageSelection(index),
+                  veggieName: veggieName!,
+                  difficulty: veggieLevel!,
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/farmclub/component/new_vegetable_select.dart
+++ b/lib/view/farmclub/component/new_vegetable_select.dart
@@ -10,10 +10,10 @@ class NewVegetableSelect extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      height: 300,
+      height: 400,
       child: GridView.builder(
         gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2, crossAxisSpacing: 8),
+            crossAxisCount: 2, crossAxisSpacing: 16),
         itemCount: 6,
         itemBuilder: (BuildContext context, int index) {
           final veggieKey =

--- a/lib/view/farmclub/component/search/brown_category.dart
+++ b/lib/view/farmclub/component/search/brown_category.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_controller.dart';
 
 class BrownCategory extends StatefulWidget {
   final String category;
@@ -17,7 +19,7 @@ class BrownCategory extends StatefulWidget {
 }
 
 class _BrownCategoryState extends State<BrownCategory> {
-  late bool isSelected = false;
+  late bool isSelected;
 
   @override
   void initState() {
@@ -31,6 +33,7 @@ class _BrownCategoryState extends State<BrownCategory> {
       onPress: () {
         setState(() {
           isSelected = !isSelected;
+          Get.find<FarmclubController>().toggleSelectCategory();
         });
       },
       child: Padding(

--- a/lib/view/farmclub/component/search/search_category.dart
+++ b/lib/view/farmclub/component/search/search_category.dart
@@ -1,17 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view/farmclub/component/search/brown_category.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_controller.dart';
 
 class SearchCategory extends StatelessWidget {
   final String title;
   final List<String> categories;
 
-  const SearchCategory(
-      {Key? key, required this.title, required this.categories})
-      : super(key: key);
+  const SearchCategory({
+    Key? key,
+    required this.title,
+    required this.categories,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
+    final FarmclubController controller = Get.find();
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
@@ -25,7 +31,12 @@ class SearchCategory extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 8),
-        ...categories.map((category) => BrownCategory(category: category)),
+        ...categories.map(
+          (category) => BrownCategory(
+            category: category,
+            isSelected: controller.isCategory.value,
+          ),
+        ),
       ],
     );
   }

--- a/lib/view/farmclub/farmclub_make_screen.dart
+++ b/lib/view/farmclub/farmclub_make_screen.dart
@@ -3,6 +3,7 @@ import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/view/farmclub/component/around/vegetable_list.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_make_edit.dart';
+import 'package:mojacknong_android/view/farmclub/component/farmclub_make_member.dart';
 import 'package:mojacknong_android/view/farmclub/component/new_vegetable_select.dart';
 import 'package:mojacknong_android/view_model/controllers/farmclub_make_controller.dart';
 
@@ -67,7 +68,9 @@ class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
             const SizedBox(
               height: 16,
             ),
-            FarmclubMakeEdit(),
+            FarmclubMakeEdit(
+              hintText: "클럽명 예시",
+            ),
             const SizedBox(
               height: 32,
             ),
@@ -78,13 +81,9 @@ class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
             const SizedBox(
               height: 16,
             ),
-            Container(
-                decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: FarmusThemeData.grey4)),
-                child: VegetableList(
-                  isMake: true,
-                )),
+            FarmclubMakeMember(
+              hintText: "",
+            ),
             const SizedBox(
               height: 32,
             ),
@@ -96,12 +95,13 @@ class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
               height: 16,
             ),
             Container(
-                decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: FarmusThemeData.grey4)),
-                child: VegetableList(
-                  isMake: true,
-                )),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: FarmclubMakeEdit(
+                hintText: "",
+              ),
+            ),
             const SizedBox(
               height: 32,
             ),

--- a/lib/view/farmclub/farmclub_make_screen.dart
+++ b/lib/view/farmclub/farmclub_make_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/view/farmclub/component/around/vegetable_list.dart';
+import 'package:mojacknong_android/view/farmclub/component/button_brown.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_make_content.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_make_edit.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_make_member.dart';
@@ -24,91 +25,110 @@ class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
       appBar: PrimaryAppBar(title: "팜클럽 개설"),
       backgroundColor: FarmusThemeData.white,
       body: SingleChildScrollView(
-          child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(
-              "함께 재배할 채소를 선택해주세요",
-              style: FarmusThemeData.darkStyle14,
-            ),
-            const SizedBox(
-              height: 16,
-            ),
-            NewVegetableSelect(),
-            const SizedBox(
-              height: 32,
-            ),
-            const Text(
-              "어떤 채소로 팜클럽에 참여할 지 선택해주세요",
-              style: FarmusThemeData.darkStyle14,
-            ),
-            const SizedBox(
-              height: 16,
-            ),
-            Container(
-                decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(color: FarmusThemeData.grey4)),
-                child: Column(
-                  children: [
-                    VegetableList(
-                      isMake: true,
-                    ),
-                  ],
-                )),
-            const SizedBox(
-              height: 32,
-            ),
-            const Text(
-              "팜클럽의 이름을 입력해주세요",
-              style: FarmusThemeData.darkStyle14,
-            ),
-            const SizedBox(
-              height: 16,
-            ),
-            FarmclubMakeEdit(
-              hintText: "클럽명 예시",
-            ),
-            const SizedBox(
-              height: 32,
-            ),
-            const Text(
-              "참여 멤버 수를 입력해주세요 (최소 3명 최대 20명)",
-              style: FarmusThemeData.darkStyle14,
-            ),
-            const SizedBox(
-              height: 16,
-            ),
-            FarmclubMakeMember(
-              hintText: "",
-            ),
-            const SizedBox(
-              height: 32,
-            ),
-            const Text(
-              "팜클럽 한 줄 소개를 입력해주세요",
-              style: FarmusThemeData.darkStyle14,
-            ),
-            const SizedBox(
-              height: 16,
-            ),
-            Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                "함께 재배할 채소를 선택해주세요",
+                style: FarmusThemeData.darkStyle14,
               ),
-              child: FarmclubMakeContent(
+              const SizedBox(
+                height: 16,
+              ),
+              NewVegetableSelect(),
+              const SizedBox(
+                height: 32,
+              ),
+              const Text(
+                "어떤 채소로 팜클럽에 참여할 지 선택해주세요",
+                style: FarmusThemeData.darkStyle14,
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              Container(
+                  decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(color: FarmusThemeData.grey4)),
+                  child: Column(
+                    children: [
+                      VegetableList(
+                        isMake: true,
+                      ),
+                    ],
+                  )),
+              const SizedBox(
+                height: 32,
+              ),
+              const Text(
+                "팜클럽의 이름을 입력해주세요",
+                style: FarmusThemeData.darkStyle14,
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              FarmclubMakeEdit(
+                hintText: "클럽명 예시",
+              ),
+              const SizedBox(
+                height: 32,
+              ),
+              const Text(
+                "참여 멤버 수를 입력해주세요 (최소 3명 최대 20명)",
+                style: FarmusThemeData.darkStyle14,
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              FarmclubMakeMember(
                 hintText: "",
               ),
-            ),
-            const SizedBox(
-              height: 32,
-            ),
-          ],
+              const SizedBox(
+                height: 32,
+              ),
+              const Text(
+                "팜클럽 한 줄 소개를 입력해주세요",
+                style: FarmusThemeData.darkStyle14,
+              ),
+              const SizedBox(
+                height: 16,
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: FarmclubMakeContent(
+                  hintText: "",
+                ),
+              ),
+              const SizedBox(
+                height: 80,
+              ),
+            ],
+          ),
         ),
-      )),
+      ),
+      floatingActionButtonLocation:
+          FloatingActionButtonLocation.miniCenterFloat,
+      floatingActionButton: Column(
+        children: [
+          Expanded(
+              child: SizedBox(
+            height: 0,
+          )),
+          Divider(
+            color: FarmusThemeData.grey4,
+          ),
+          ButtonBrown(
+            text: "개설화기",
+            enabled: _controller.isFormVaild,
+            onPress: () {},
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/view/farmclub/farmclub_make_screen.dart
+++ b/lib/view/farmclub/farmclub_make_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/view/farmclub/component/around/vegetable_list.dart';
+import 'package:mojacknong_android/view/farmclub/component/farmclub_make_content.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_make_edit.dart';
 import 'package:mojacknong_android/view/farmclub/component/farmclub_make_member.dart';
 import 'package:mojacknong_android/view/farmclub/component/new_vegetable_select.dart';
@@ -98,7 +99,7 @@ class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(8),
               ),
-              child: FarmclubMakeEdit(
+              child: FarmclubMakeContent(
                 hintText: "",
               ),
             ),

--- a/lib/view/farmclub/farmclub_make_screen.dart
+++ b/lib/view/farmclub/farmclub_make_screen.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
+import 'package:mojacknong_android/view/farmclub/component/around/vegetable_list.dart';
+import 'package:mojacknong_android/view/farmclub/component/farmclub_make_edit.dart';
 import 'package:mojacknong_android/view/farmclub/component/new_vegetable_select.dart';
+import 'package:mojacknong_android/view_model/controllers/farmclub_make_controller.dart';
 
 class FarmclubMakeScreen extends StatefulWidget {
   const FarmclubMakeScreen({super.key});
@@ -11,6 +14,8 @@ class FarmclubMakeScreen extends StatefulWidget {
 }
 
 class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
+  FarmclubMakeController _controller = FarmclubMakeController();
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -23,15 +28,83 @@ class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
+            const Text(
               "함께 재배할 채소를 선택해주세요",
               style: FarmusThemeData.darkStyle14,
             ),
-            SizedBox(
+            const SizedBox(
               height: 16,
             ),
             NewVegetableSelect(),
-            Text("data")
+            const SizedBox(
+              height: 32,
+            ),
+            const Text(
+              "어떤 채소로 팜클럽에 참여할 지 선택해주세요",
+              style: FarmusThemeData.darkStyle14,
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            Container(
+                decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: FarmusThemeData.grey4)),
+                child: Column(
+                  children: [
+                    VegetableList(
+                      isMake: true,
+                    ),
+                  ],
+                )),
+            const SizedBox(
+              height: 32,
+            ),
+            const Text(
+              "팜클럽의 이름을 입력해주세요",
+              style: FarmusThemeData.darkStyle14,
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            FarmclubMakeEdit(),
+            const SizedBox(
+              height: 32,
+            ),
+            const Text(
+              "참여 멤버 수를 입력해주세요 (최소 3명 최대 20명)",
+              style: FarmusThemeData.darkStyle14,
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            Container(
+                decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: FarmusThemeData.grey4)),
+                child: VegetableList(
+                  isMake: true,
+                )),
+            const SizedBox(
+              height: 32,
+            ),
+            const Text(
+              "팜클럽 한 줄 소개를 입력해주세요",
+              style: FarmusThemeData.darkStyle14,
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            Container(
+                decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: FarmusThemeData.grey4)),
+                child: VegetableList(
+                  isMake: true,
+                )),
+            const SizedBox(
+              height: 32,
+            ),
           ],
         ),
       )),

--- a/lib/view/farmclub/farmclub_make_screen.dart
+++ b/lib/view/farmclub/farmclub_make_screen.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/common/primary_app_bar.dart';
+import 'package:mojacknong_android/view/farmclub/component/new_vegetable_select.dart';
+
+class FarmclubMakeScreen extends StatefulWidget {
+  const FarmclubMakeScreen({super.key});
+
+  @override
+  State<FarmclubMakeScreen> createState() => _FarmclubMakeScreenState();
+}
+
+class _FarmclubMakeScreenState extends State<FarmclubMakeScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PrimaryAppBar(title: "팜클럽 개설"),
+      backgroundColor: FarmusThemeData.white,
+      body: SingleChildScrollView(
+          child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              "함께 재배할 채소를 선택해주세요",
+              style: FarmusThemeData.darkStyle14,
+            ),
+            SizedBox(
+              height: 16,
+            ),
+            NewVegetableSelect(),
+            Text("data")
+          ],
+        ),
+      )),
+    );
+  }
+}

--- a/lib/view/my_page/component/my_page_header.dart
+++ b/lib/view/my_page/component/my_page_header.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_profile.dart';
+import 'package:mojacknong_android/view/my_page/my_page_setting_screen.dart';
 
 class MyPageHeader extends StatelessWidget {
   final String? name;
   final int? date;
   final String? imagePath;
-
 
   MyPageHeader({
     Key? key,
@@ -100,13 +101,22 @@ class MyPageHeader extends StatelessWidget {
                   Positioned(
                     top: 1,
                     right: -5,
-                    child: IconButton(
-                      iconSize: 50,
-                      onPressed: () {
-                        // setting click 시 todo
-                      },
-                      icon: SvgPicture.asset(
-                        "assets/image/settings_icon.svg",
+                    child: Bouncing(
+                      onPress: () {},
+                      child: GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) {
+                                return MyPageSettingScreen();
+                              },
+                            ),
+                          );
+                        },
+                        child: SvgPicture.asset(
+                          "assets/image/settings_icon.svg",
+                        ),
                       ),
                     ),
                   ),

--- a/lib/view/my_page/component/my_page_setting_text.dart
+++ b/lib/view/my_page/component/my_page_setting_text.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+
+class MyPageSettingText extends StatelessWidget {
+  final String text;
+  const MyPageSettingText({
+    super.key,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            height: 16,
+          ),
+          Text(
+            text,
+            style: FarmusThemeData.darkStyle16,
+            textAlign: TextAlign.left,
+          ),
+          SizedBox(
+            height: 16,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/my_page/component/my_page_setting_text.dart
+++ b/lib/view/my_page/component/my_page_setting_text.dart
@@ -1,12 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/bottom_sheet_controller.dart';
 
-class MyPageSettingText extends StatelessWidget {
+class MyPageSettingText extends StatefulWidget {
   final String text;
-  const MyPageSettingText({
-    super.key,
-    required this.text,
-  });
+  final Function()? onPress;
+
+  const MyPageSettingText({super.key, required this.text, this.onPress});
+
+  @override
+  State<MyPageSettingText> createState() => _MyPageSettingTextState();
+}
+
+class _MyPageSettingTextState extends State<MyPageSettingText> {
+  BottomSheetController controller = BottomSheetController();
 
   @override
   Widget build(BuildContext context) {
@@ -19,10 +26,13 @@ class MyPageSettingText extends StatelessWidget {
           SizedBox(
             height: 16,
           ),
-          Text(
-            text,
-            style: FarmusThemeData.darkStyle16,
-            textAlign: TextAlign.left,
+          GestureDetector(
+            onTap: widget.onPress != null ? widget.onPress : () {},
+            child: Text(
+              widget.text,
+              style: FarmusThemeData.darkStyle16,
+              textAlign: TextAlign.left,
+            ),
           ),
           SizedBox(
             height: 16,

--- a/lib/view/my_page/my_page_screen.dart
+++ b/lib/view/my_page/my_page_screen.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view/my_page/component/my_challenge_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_history_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_header.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_history.dart';
+
 import '../../model/farmus_user.dart';
 import '../../model/mypage_history.dart';
 import '../../repository/mypage_repository.dart';
@@ -26,24 +26,25 @@ class _MyPageScreenState extends State<MyPageScreen> {
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 print("화면 로딩 중");
-                return CircularProgressIndicator();
+                return Center(
+                    child: CircularProgressIndicator(
+                  color: FarmusThemeData.background,
+                ));
               } else if (snapshot.hasError) {
                 // 에러가 발생한 경우
                 return Text('Error: ${snapshot.error}');
               } else {
                 // 데이터가 성공적으로 도착한 경우
-            //  final data = snapshot.data;
+                //  final data = snapshot.data;
                 final List<dynamic> data = snapshot.data as List<dynamic>;
                 final FarmusUser? user = data[0] as FarmusUser?;
                 final MypageHistory? history = data[1] as MypageHistory?;
-
 
                 return Column(children: <Widget>[
                   MyPageHeader(
                       name: user?.nickName,
                       date: user?.dday,
-                      imagePath: user?.userImageUrl
-                  ), // 사용자 정의 헤더를 여기에 넣습니다.
+                      imagePath: user?.userImageUrl), // 사용자 정의 헤더를 여기에 넣습니다.
                   const SizedBox(height: 12.0), // 필요한 공간을 추가합니다.
 
                   HistoryHeader(historyType: "채소 히스토리"),
@@ -51,22 +52,32 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   Expanded(
                     child: history?.veggieHistoryDetailList != null
                         ? ListView.builder(
-                      padding: const EdgeInsets.only(top: 4.0),
-                      itemCount: min(3, history!.veggieHistoryDetailList.length),
-                      itemBuilder: (context, index) {
-                        final reversedIndex = history.veggieHistoryDetailList.length - index - 1;
-                        return MyPageHistory(
-                          name: history.veggieHistoryDetailList[reversedIndex].name,
-                          veggieName: history.veggieHistoryDetailList[reversedIndex].veggieName,
-                          period: history.veggieHistoryDetailList[reversedIndex].period,
-                          image: history.veggieHistoryDetailList[reversedIndex].image,
-                        );
-                      },
-                    )
+                            padding: const EdgeInsets.only(top: 4.0),
+                            itemCount:
+                                min(3, history!.veggieHistoryDetailList.length),
+                            itemBuilder: (context, index) {
+                              final reversedIndex =
+                                  history.veggieHistoryDetailList.length -
+                                      index -
+                                      1;
+                              return MyPageHistory(
+                                name: history
+                                    .veggieHistoryDetailList[reversedIndex]
+                                    .name,
+                                veggieName: history
+                                    .veggieHistoryDetailList[reversedIndex]
+                                    .veggieName,
+                                period: history
+                                    .veggieHistoryDetailList[reversedIndex]
+                                    .period,
+                                image: history
+                                    .veggieHistoryDetailList[reversedIndex]
+                                    .image,
+                              );
+                            },
+                          )
                         : noData(),
                   ),
-
-
 
                   const SizedBox(height: 10.0),
                   ChallengeHeader(historyType: "팜클럽 히스토리"),
@@ -74,47 +85,46 @@ class _MyPageScreenState extends State<MyPageScreen> {
                   Expanded(
                     child: history?.farmClubHistoryDetailList != null
                         ? ListView.builder(
-                      padding: const EdgeInsets.only(top: 4.0),
-                      itemCount: min(3, history!.farmClubHistoryDetailList.length),
-                      itemBuilder: (context, index) {
-                        print(22);
-                        final reversedIndex = history.farmClubHistoryDetailList.length - index - 1;
-                        return MyPageHistory(
-                          name: history.farmClubHistoryDetailList[reversedIndex].name,
-                          veggieName: history.farmClubHistoryDetailList[reversedIndex].veggieName,
-                          period: history.farmClubHistoryDetailList[reversedIndex].period,
-                          image: history.farmClubHistoryDetailList[reversedIndex].image,
-                        );
-                      },
-                    )
+                            padding: const EdgeInsets.only(top: 4.0),
+                            itemCount: min(
+                                3, history!.farmClubHistoryDetailList.length),
+                            itemBuilder: (context, index) {
+                              print(22);
+                              final reversedIndex =
+                                  history.farmClubHistoryDetailList.length -
+                                      index -
+                                      1;
+                              return MyPageHistory(
+                                name: history
+                                    .farmClubHistoryDetailList[reversedIndex]
+                                    .name,
+                                veggieName: history
+                                    .farmClubHistoryDetailList[reversedIndex]
+                                    .veggieName,
+                                period: history
+                                    .farmClubHistoryDetailList[reversedIndex]
+                                    .period,
+                                image: history
+                                    .farmClubHistoryDetailList[reversedIndex]
+                                    .image,
+                              );
+                            },
+                          )
                         : noData(),
                   ),
-
-
                 ]);
               }
-            }
-            )
-    );
+            }));
   }
 
-  bool isCheckNull(List<dynamic>? list){
-    if(list!.isEmpty){
-
+  bool isCheckNull(List<dynamic>? list) {
+    if (list!.isEmpty) {
       return true;
-
     }
     return false;
   }
 
-  Center noData(){
-    return const Center(
-      child: Text("히스토리가 없습니다.")
-    );
+  Center noData() {
+    return const Center(child: Text("히스토리가 없습니다."));
   }
-
-
-
-
-
 }

--- a/lib/view/my_page/my_page_setting_screen.dart
+++ b/lib/view/my_page/my_page_setting_screen.dart
@@ -1,10 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
 import 'package:mojacknong_android/view/my_page/component/my_page_setting_text.dart';
+import 'package:mojacknong_android/view_model/controllers/bottom_sheet_controller.dart';
 
-class MyPageSettingScreen extends StatelessWidget {
+class MyPageSettingScreen extends StatefulWidget {
   const MyPageSettingScreen({super.key});
+
+  @override
+  State<MyPageSettingScreen> createState() => _MyPageSettingScreenState();
+}
+
+class _MyPageSettingScreenState extends State<MyPageSettingScreen> {
+  BottomSheetController _controller = Get.put(BottomSheetController());
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +45,7 @@ class MyPageSettingScreen extends StatelessWidget {
           SizedBox(
             height: 16,
           ),
-          const Divider(
+          Divider(
             thickness: 12,
             color: FarmusThemeData.dividerBackground,
           ),
@@ -45,6 +54,14 @@ class MyPageSettingScreen extends StatelessWidget {
           ),
           MyPageSettingText(
             text: "로그아웃",
+            onPress: () {
+              _controller.showActionSheetRedMessage(
+                context,
+                message: "로그아웃하시겠어요?",
+                confirmText: "로그아웃하기",
+                cancelButtonText: "취소",
+              );
+            },
           ),
           Divider(
             color: FarmusThemeData.grey4,

--- a/lib/view/my_page/my_page_setting_screen.dart
+++ b/lib/view/my_page/my_page_setting_screen.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/common/primary_app_bar.dart';
+import 'package:mojacknong_android/view/my_page/component/my_page_setting_text.dart';
+
+class MyPageSettingScreen extends StatelessWidget {
+  const MyPageSettingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: PrimaryAppBar(title: "설정"),
+      backgroundColor: FarmusThemeData.white,
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          MyPageSettingText(
+            text: "푸시알림",
+          ),
+          Divider(
+            color: FarmusThemeData.grey4,
+            indent: 16,
+            endIndent: 16,
+          ),
+          MyPageSettingText(
+            text: "개인정보 처리 방침",
+          ),
+          Divider(
+            color: FarmusThemeData.grey4,
+            indent: 16,
+            endIndent: 16,
+          ),
+          MyPageSettingText(
+            text: "서비스 이용약관",
+          ),
+          SizedBox(
+            height: 16,
+          ),
+          const Divider(
+            thickness: 12,
+            color: FarmusThemeData.dividerBackground,
+          ),
+          SizedBox(
+            height: 16,
+          ),
+          MyPageSettingText(
+            text: "로그아웃",
+          ),
+          Divider(
+            color: FarmusThemeData.grey4,
+            indent: 16,
+            endIndent: 16,
+          ),
+          MyPageSettingText(
+            text: "탈퇴하기",
+          ),
+          Divider(
+            color: FarmusThemeData.grey4,
+            indent: 16,
+            endIndent: 16,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/onboarding/component/nickname_field.dart
+++ b/lib/view/onboarding/component/nickname_field.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/onboarding_controller.dart';
+
+class NicknameField extends StatefulWidget {
+  const NicknameField({super.key});
+
+  @override
+  State<NicknameField> createState() => _NicknameFieldState();
+}
+
+class _NicknameFieldState extends State<NicknameField> {
+  OnboardingController _controller = Get.find();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Obx(
+        () => TextFormField(
+          controller: _controller.controller,
+          maxLength: 10,
+          decoration: InputDecoration(
+            hintText: "파머",
+            hintStyle: const TextStyle(
+              color: FarmusThemeData.grey3,
+              fontFamily: "Pretendard",
+            ),
+            errorText: _controller.hasSpecialCharacters.value
+                ? '특수문자는 입력할 수 없어요'
+                : null,
+            enabledBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: const BorderSide(
+                color: FarmusThemeData.grey4,
+              ),
+            ),
+            focusedBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: const BorderSide(
+                color: FarmusThemeData.grey4,
+              ),
+            ),
+            focusedErrorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: const BorderSide(
+                color: FarmusThemeData.grey4,
+              ),
+            ),
+            errorBorder: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(16),
+              borderSide: const BorderSide(
+                color: FarmusThemeData.grey4,
+              ),
+            ),
+            errorStyle: const TextStyle(
+              color: FarmusThemeData.red,
+            ),
+            contentPadding: const EdgeInsets.symmetric(
+              vertical: 12.0,
+              horizontal: 16.0,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view_model/controllers/bottom_sheet_controller.dart
+++ b/lib/view_model/controllers/bottom_sheet_controller.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mojacknong_android/common/bottom_sheet/bottom_sheet_farmclub_exit.dart';
 import 'package:mojacknong_android/common/bottom_sheet/bottom_sheet_farmclub_join.dart';
+import 'package:mojacknong_android/common/bottom_sheet/cupertino_action_sheet_helper.dart';
 import 'package:mojacknong_android/common/dialog/Dialog_join_farmclub.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/view/home/component/register/customs/Dialog_register_vege.dart';
@@ -14,48 +14,21 @@ class BottomSheetController extends GetxController {
     required String cancelText,
     required String confirmText,
   }) {
-    showCupertinoModalPopup<void>(
-      context: context!,
-      builder: (BuildContext context) => CupertinoActionSheet(
-        message: Text(
-          message,
-          style: const TextStyle(
-            color: FarmusThemeData.grey2,
-            fontSize: 12,
-            fontFamily: "Pretendard",
-          ),
-        ),
-        actions: <CupertinoActionSheetAction>[
-          CupertinoActionSheetAction(
-            isDestructiveAction: true,
-            onPressed: () {
-              Navigator.pop(context);
-            },
-            child: Text(
-              cancelText,
-              style: const TextStyle(
-                color: FarmusThemeData.dark,
-                fontSize: 14,
-                fontFamily: "Pretendard",
-              ),
-            ),
-          ),
-          CupertinoActionSheetAction(
-            onPressed: () {
-              Navigator.pop(context);
-            },
-            child: Text(
-              confirmText,
-              style: const TextStyle(
-                color: FarmusThemeData.dark,
-                fontSize: 14,
-                fontFamily: "Pretendard",
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
+    CupertinoActionSheetHelper.showActionSheetComment(context,
+        message: message, cancelText: cancelText, confirmText: confirmText);
+  }
+
+  void showActionSheetRedMessage(
+    BuildContext? context, {
+    String? title,
+    required String message,
+    required String confirmText,
+    required String cancelButtonText,
+  }) {
+    CupertinoActionSheetHelper.showActionSheetRedMessage(context!,
+        message: message,
+        confirmText: confirmText,
+        cancelText: cancelButtonText);
   }
 
   void showCustomCupertinoActionSheet(
@@ -64,7 +37,14 @@ class BottomSheetController extends GetxController {
     required String message,
     required List<String> options,
     required String cancelButtonText,
-  }) {}
+  }) {
+    CupertinoActionSheetHelper.showCustomCupertinoActionSheet(
+      context!,
+      message: message,
+      options: options,
+      cancelButtonText: cancelButtonText,
+    );
+  }
 
   void showFarmclubJoinBottomSheet(BuildContext context, String title) {
     showModalBottomSheet<void>(

--- a/lib/view_model/controllers/farmclub_controller.dart
+++ b/lib/view_model/controllers/farmclub_controller.dart
@@ -5,7 +5,6 @@ import 'package:get/get.dart';
 
 class FarmclubController extends GetxController {
   final TextEditingController controller = TextEditingController();
-  RxBool hasSpecialCharacters = RxBool(false);
   RxBool hasInput = RxBool(false);
 
   RxBool isSelectLike = RxBool(false);

--- a/lib/view_model/controllers/farmclub_controller.dart
+++ b/lib/view_model/controllers/farmclub_controller.dart
@@ -12,6 +12,7 @@ class FarmclubController extends GetxController {
   RxInt like = 2.obs; // 초기 좋아요 수
 
   RxBool isCheck = RxBool(false);
+  RxBool isCategory = RxBool(false);
   RxBool shouldExit = RxBool(false);
 
   RxBool isTextBox1Selected = RxBool(false);
@@ -54,6 +55,10 @@ class FarmclubController extends GetxController {
 
   void checkFormVaildity() {
     isFormVaild.value = contentValue.isNotEmpty && image.value != null;
+  }
+
+  void toggleSelectCategory() {
+    isCategory.value = !isCategory.value;
   }
 
   void toggleSelectCheck() {

--- a/lib/view_model/controllers/farmclub_make_controller.dart
+++ b/lib/view_model/controllers/farmclub_make_controller.dart
@@ -1,0 +1,54 @@
+import 'package:get/get.dart';
+
+class FarmclubMakeController extends GetxController {
+  // 선택된 채소들의 상태를 저장하는 변수
+  RxList<bool> isSelectedList = List.generate(6, (index) => false).obs;
+
+  RxMap veggieData = {}.obs;
+  RxMap veggieLevel = {}.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    initializeVeggieData();
+    initializeVeggieLevel();
+  }
+
+  // 선택된 이미지의 상태를 토글하고 다른 선택 상태를 해제하는 메서드
+  void toggleImageSelection(int index) {
+    for (int i = 0; i < isSelectedList.length; i++) {
+      if (i == index) {
+        // 현재 선택한 아이템이면 반전
+        isSelectedList[i] = !isSelectedList[i];
+      } else {
+        // 다른 아이템은 선택 해제
+        isSelectedList[i] = false;
+      }
+    }
+    update();
+  }
+
+  // 채소 데이터를 초기화하는 메서드
+  void initializeVeggieData() {
+    veggieData.addAll({
+      'lettuce': '상추',
+      'greenonion': '대파',
+      'basil': '바질',
+      'sesame': '깻잎',
+      'pepper': '고추',
+      'tomato': '토마토',
+    });
+  }
+
+  // 난이도 데이터를 초기화하는 메서드
+  void initializeVeggieLevel() {
+    veggieLevel.addAll({
+      'lettuce': 'Easy',
+      'greenonion': 'Easy',
+      'basil': 'Normal',
+      'sesame': 'Normal',
+      'pepper': 'Hard',
+      'tomato': 'Hard',
+    });
+  }
+}

--- a/lib/view_model/controllers/farmclub_make_controller.dart
+++ b/lib/view_model/controllers/farmclub_make_controller.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 class FarmclubMakeController extends GetxController {
   // 선택된 채소들의 상태를 저장하는 변수
   RxList<bool> isSelectedList = List.generate(6, (index) => false).obs;
+  RxInt selectedVeggieIndex = RxInt(-1);
 
   RxMap veggieData = {}.obs;
   RxMap veggieLevel = {}.obs;
@@ -23,12 +24,32 @@ class FarmclubMakeController extends GetxController {
   RxBool hasMemberInput = RxBool(false);
   RxBool hasIntroInput = RxBool(false);
 
+  final isFormVaild = RxBool(false);
+
   @override
   void onInit() {
     super.onInit();
     initHasText();
     initializeVeggieData();
     initializeVeggieLevel();
+
+    ever(titleValue, (_) {
+      checkFormVaildity();
+    });
+
+    ever(memberValue, (_) {
+      checkFormVaildity();
+    });
+
+    ever(contentValue, (_) {
+      checkFormVaildity();
+    });
+  }
+
+  // 선택된 채소의 인덱스를 업데이트하는 메서드
+  void updateSelectedVeggieIndex(int index) {
+    selectedVeggieIndex.value = index;
+    checkFormVaildity(); // 선택된 채소가 변경될 때마다 폼 유효성을 다시 확인
   }
 
   void initHasText() {
@@ -59,6 +80,8 @@ class FarmclubMakeController extends GetxController {
         isSelectedList[i] = false;
       }
     }
+    print(index);
+    updateSelectedVeggieIndex(index);
     update(); // 상태 업데이트
   }
 
@@ -96,5 +119,10 @@ class FarmclubMakeController extends GetxController {
 
   void updateContentValue(String value) {
     contentValue.value = value;
+  }
+
+  void checkFormVaildity() {
+    selectedVeggieIndex.value != null;
+    update(); // 추가: 상태 업데이트
   }
 }

--- a/lib/view_model/controllers/farmclub_make_controller.dart
+++ b/lib/view_model/controllers/farmclub_make_controller.dart
@@ -11,7 +11,16 @@ class FarmclubMakeController extends GetxController {
   final TextEditingController controller = TextEditingController();
   RxBool hasInput = RxBool(false);
 
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController memberController = TextEditingController();
+  final TextEditingController introController = TextEditingController();
+
   final contentValue = "".obs;
+  final memberValue = "".obs;
+
+  RxBool hasNameInput = RxBool(false);
+  RxBool hasMemberInput = RxBool(false);
+  RxBool hasIntroInput = RxBool(false);
 
   @override
   void onInit() {
@@ -22,15 +31,19 @@ class FarmclubMakeController extends GetxController {
   }
 
   void initHasText() {
-    // 텍스트 필드의 값이 변경될 때 호출되는 함수
-    controller.addListener(() {
-      final value = controller.text;
-      // 텍스트 필드에 값이 입력 되었는지 여부
-      if (value.isNotEmpty) {
-        hasInput.value = true;
-      } else {
-        hasInput.value = false;
-      }
+    nameController.addListener(() {
+      hasNameInput.value = nameController.text.isNotEmpty;
+      update();
+    });
+
+    memberController.addListener(() {
+      hasMemberInput.value = memberController.text.isNotEmpty;
+      update();
+    });
+
+    introController.addListener(() {
+      hasIntroInput.value = introController.text.isNotEmpty;
+      update();
     });
   }
 
@@ -74,5 +87,9 @@ class FarmclubMakeController extends GetxController {
 
   void updateContentValue(String value) {
     contentValue.value = value;
+  }
+
+  void updateMemberValue(String value) {
+    memberValue.value = value;
   }
 }

--- a/lib/view_model/controllers/farmclub_make_controller.dart
+++ b/lib/view_model/controllers/farmclub_make_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 class FarmclubMakeController extends GetxController {
@@ -7,11 +8,30 @@ class FarmclubMakeController extends GetxController {
   RxMap veggieData = {}.obs;
   RxMap veggieLevel = {}.obs;
 
+  final TextEditingController controller = TextEditingController();
+  RxBool hasInput = RxBool(false);
+
+  final contentValue = "".obs;
+
   @override
   void onInit() {
     super.onInit();
+    initHasText();
     initializeVeggieData();
     initializeVeggieLevel();
+  }
+
+  void initHasText() {
+    // 텍스트 필드의 값이 변경될 때 호출되는 함수
+    controller.addListener(() {
+      final value = controller.text;
+      // 텍스트 필드에 값이 입력 되었는지 여부
+      if (value.isNotEmpty) {
+        hasInput.value = true;
+      } else {
+        hasInput.value = false;
+      }
+    });
   }
 
   // 선택된 이미지의 상태를 토글하고 다른 선택 상태를 해제하는 메서드
@@ -25,7 +45,7 @@ class FarmclubMakeController extends GetxController {
         isSelectedList[i] = false;
       }
     }
-    update();
+    update(); // 상태 업데이트
   }
 
   // 채소 데이터를 초기화하는 메서드
@@ -50,5 +70,9 @@ class FarmclubMakeController extends GetxController {
       'pepper': 'Hard',
       'tomato': 'Hard',
     });
+  }
+
+  void updateContentValue(String value) {
+    contentValue.value = value;
   }
 }

--- a/lib/view_model/controllers/farmclub_make_controller.dart
+++ b/lib/view_model/controllers/farmclub_make_controller.dart
@@ -15,8 +15,9 @@ class FarmclubMakeController extends GetxController {
   final TextEditingController memberController = TextEditingController();
   final TextEditingController introController = TextEditingController();
 
-  final contentValue = "".obs;
+  final titleValue = "".obs;
   final memberValue = "".obs;
+  final contentValue = "".obs;
 
   RxBool hasNameInput = RxBool(false);
   RxBool hasMemberInput = RxBool(false);
@@ -85,11 +86,15 @@ class FarmclubMakeController extends GetxController {
     });
   }
 
-  void updateContentValue(String value) {
-    contentValue.value = value;
+  void updateTitleValue(String value) {
+    titleValue.value = value;
   }
 
   void updateMemberValue(String value) {
     memberValue.value = value;
+  }
+
+  void updateContentValue(String value) {
+    contentValue.value = value;
   }
 }


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #55 

### 🍠 Summary
팜클럽 개설하기 화면을 구현하였습니다.

개설하기 버튼은 아직 미완성이고,
마이페이지 설정 화면에서 로그아웃 버튼을 클릭했을 때 로그아웃 바텀 시트가 띄워집니다.
CupertinoActionSheetHelper에 아이폰 기본 바텀시트 디자인을 불러오는 코드를 작성했습니다.

### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
