### PR TITLE
[Refactor] PrimaryTabBar 수정 및 적용 

### DIFF
--- a/lib/common/base/base_tab_bar.dart
+++ b/lib/common/base/base_tab_bar.dart
@@ -3,4 +3,5 @@ import 'package:flutter/cupertino.dart';
 abstract class BaseTabBar {
   List<String> get tab;
   List<Widget> get tabView;
+  double? get tabViewHeights;
 }

--- a/lib/common/tab_bar/farmclub_tab_bar.dart
+++ b/lib/common/tab_bar/farmclub_tab_bar.dart
@@ -75,6 +75,7 @@ class FarmclubTabBar extends StatelessWidget {
         ),
         Container(),
       ],
+      tabViewHeights: 368,
     );
   }
 }

--- a/lib/common/tab_bar/primary_tab_bar.dart
+++ b/lib/common/tab_bar/primary_tab_bar.dart
@@ -5,15 +5,23 @@ import 'package:flutter/material.dart';
 import '../../../common/theme/farmus_theme_color.dart';
 
 class PrimaryTabBar extends StatelessWidget implements BaseTabBar {
-  const PrimaryTabBar(
-      {super.key, required this.tab, required this.tabView});
+  const PrimaryTabBar({
+    Key? key,
+    required this.tab,
+    required this.tabView,
+    this.tabViewHeights,
+    this.labelStyle,
+    this.unselectedLabelStyle,
+  }) : super(key: key);
 
   @override
   final List<String> tab;
-
   @override
   final List<Widget> tabView;
-
+  @override
+  final double? tabViewHeights;
+  final TextStyle? labelStyle;
+  final TextStyle? unselectedLabelStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -27,24 +35,32 @@ class PrimaryTabBar extends StatelessWidget implements BaseTabBar {
             indicator: const UnderlineTabIndicator(
               borderSide: BorderSide(width: 2, color: FarmusThemeColor.dark),
             ),
-            labelStyle: FarmusThemeTextStyle.darkSemiBold17,
-            unselectedLabelStyle: FarmusThemeTextStyle.gray3SemiBold17,
+            labelStyle: labelStyle ?? FarmusThemeTextStyle.darkSemiBold17,
+            unselectedLabelStyle:
+                unselectedLabelStyle ?? FarmusThemeTextStyle.gray3SemiBold17,
             isScrollable: true,
             tabAlignment: TabAlignment.start,
             tabs: tab.map((tabs) => Tab(text: tabs)).toList(),
           ),
-          SizedBox(
-            width: double.infinity,
-            height: 368,
-            child: TabBarView(
-              children: [
-                for (var child in tabView) child,
-              ],
+          if (tabViewHeights != null)
+            SizedBox(
+              height: tabViewHeights,
+              child: TabBarView(
+                children: tabView,
+              ),
+            )
+          else
+            Expanded(
+              child: TabBarView(
+                children: tabView.map((widget) {
+                  return SingleChildScrollView(
+                    child: widget,
+                  );
+                }).toList(),
+              ),
             ),
-          ),
         ],
       ),
     );
   }
-
 }

--- a/lib/view/my_farmclub/component/my_farmclub_stack_box.dart
+++ b/lib/view/my_farmclub/component/my_farmclub_stack_box.dart
@@ -75,13 +75,19 @@ class MyFarmClubStackBox extends ConsumerWidget {
         ),
         const Positioned(
           child: Padding(
-            padding: EdgeInsets.only(top: 105.0, left: 24),
-            child: Row(
-              children: [
-                FarmclubWidgetPic(),
-                FarmclubWidgetPic(),
-                FarmclubWidgetPic()
-              ],
+            padding: EdgeInsets.only(top: 105.0, left: 24, right: 24),
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  FarmclubWidgetPic(),
+                  FarmclubWidgetPic(),
+                  FarmclubWidgetPic(),
+                  FarmclubWidgetPic(),
+                  FarmclubWidgetPic(),
+                  FarmclubWidgetPic()
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/view/my_page/component/my_history_box.dart
+++ b/lib/view/my_page/component/my_history_box.dart
@@ -2,8 +2,8 @@ import 'package:farmus/common/theme/farmus_theme_color.dart';
 import 'package:farmus/view/vege_history/vege_history_list_screen.dart';
 import 'package:flutter/material.dart';
 
-class MyVegeBox extends StatelessWidget {
-  const MyVegeBox({super.key});
+class MyHistoryBox extends StatelessWidget {
+  const MyHistoryBox({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/my_page/component/my_vege_stack_box.dart
+++ b/lib/view/my_page/component/my_vege_stack_box.dart
@@ -25,7 +25,7 @@ class MyVegeStackBox extends ConsumerWidget {
 
     return Stack(
       children: [
-        const MyVegeBox(),
+        const MyHistoryBox(),
         Padding(
           padding: const EdgeInsets.only(left: 32, top: 20),
           child: Column(
@@ -66,9 +66,18 @@ class MyVegeStackBox extends ConsumerWidget {
         ),
         const Positioned(
           child: Padding(
-            padding: EdgeInsets.only(top: 90.0, left: 24),
-            child: Row(
-              children: [MyVegeImageWidget(), MyVegeImageWidget()],
+            padding: EdgeInsets.only(top: 90.0, left: 24, right: 24),
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: [
+                  MyVegeImageWidget(),
+                  MyVegeImageWidget(),
+                  MyVegeImageWidget(),
+                  MyVegeImageWidget(),
+                  MyVegeImageWidget()
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/view/my_page/my_page_screen.dart
+++ b/lib/view/my_page/my_page_screen.dart
@@ -32,6 +32,9 @@ class MyPageScreen extends StatelessWidget {
             ),
             SizedBox(
               child: MyHistory(),
+            ),
+            SizedBox(
+              height: 30,
             )
           ],
         ),

--- a/lib/view/search/component/search_tab_bar.dart
+++ b/lib/view/search/component/search_tab_bar.dart
@@ -1,87 +1,35 @@
-import 'package:farmus/common/theme/farmus_theme_color.dart';
+import 'package:farmus/common/tab_bar/primary_tab_bar.dart';
 import 'package:farmus/view/search/component/search_vege_info.dart';
 import 'package:flutter/material.dart';
 
-class SearchTabBar extends StatefulWidget {
-  const SearchTabBar({super.key});
+class SearchTabBar extends StatelessWidget {
+  const SearchTabBar({
+    Key? key,
+  }) : super(key: key);
 
-  @override
-  State<SearchTabBar> createState() => _SearchTabBarState();
-}
-
-class _SearchTabBarState extends State<SearchTabBar> {
   @override
   Widget build(BuildContext context) {
-    return const DefaultTabController(
-      length: 2,
-      child: Column(
-        children: <Widget>[
-          Padding(
-            padding: EdgeInsets.only(left: 8.0),
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: SizedBox(
-                width: 120,
-                child: Material(
-                  color: Colors.white,
-                  child: TabBar(
-                    indicator: UnderlineTabIndicator(
-                      borderSide:
-                          BorderSide(width: 2.5, color: FarmusThemeColor.dark),
-                    ),
-                    labelColor: FarmusThemeColor.dark,
-                    unselectedLabelColor: FarmusThemeColor.gray3,
-                    tabs: [
-                      Tab(
-                        child: Text(
-                          "상추",
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
-                      Tab(
-                        child: Text(
-                          "대파",
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
+    return const PrimaryTabBar(
+      tab: ["상추", "대파"],
+      tabView: [
+        Padding(
+          padding: EdgeInsets.all(16),
+          child: SearchVegeInfo(
+            day: "1",
+            num: "5",
+            total: "8",
           ),
-          Divider(
-            thickness: 1.0,
-            height: 1,
+        ),
+        Padding(
+          padding: EdgeInsets.all(16),
+          child: SearchVegeInfo(
+            day: "5",
+            num: "5",
+            total: "8",
           ),
-          SizedBox(
-            width: double.infinity,
-            height: 260,
-            child: TabBarView(
-              children: [
-                Center(
-                    child: SearchVegeInfo(
-                  day: "1",
-                  num: "5",
-                  total: "8",
-                )),
-                Center(
-                    child: SearchVegeInfo(
-                  day: "5",
-                  num: "5",
-                  total: "8",
-                )),
-              ],
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
+      tabViewHeights: 280,
     );
   }
 }

--- a/lib/view/search/component/search_vege_info.dart
+++ b/lib/view/search/component/search_vege_info.dart
@@ -20,9 +20,9 @@ class SearchVegeInfo extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return GestureDetector(
       onTap: () {},
-      child: Container(
+      child: SizedBox(
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.only(bottom: 16.0),
           child: VegeInfoDetail(
             info: {
               '채소': '상추',

--- a/lib/view/search/search_screen.dart
+++ b/lib/view/search/search_screen.dart
@@ -76,7 +76,6 @@ class _SearchScreenState extends ConsumerState<SearchScreen> {
               child: Column(
                 children: [
                   SearchTabBar(),
-                  SizedBox(height: 16),
                   Padding(
                     padding: EdgeInsets.symmetric(horizontal: 16.0),
                     child: Row(

--- a/lib/view/vege_history/component/vege_history_tap_bar.dart
+++ b/lib/view/vege_history/component/vege_history_tap_bar.dart
@@ -1,4 +1,5 @@
-import 'package:farmus/common/theme/farmus_theme_color.dart';
+import 'package:farmus/common/tab_bar/primary_tab_bar.dart';
+import 'package:farmus/common/theme/farmus_theme_text_style.dart';
 import 'package:farmus/view/my_page/my_page_feed/my_page_feed_list.dart';
 import 'package:flutter/material.dart';
 
@@ -12,64 +13,11 @@ class VegeHistoryTabBar extends StatefulWidget {
 class _VegeHistoryTabBarState extends State<VegeHistoryTabBar> {
   @override
   Widget build(BuildContext context) {
-    return const DefaultTabController(
-      length: 2,
-      child: Column(
-        children: <Widget>[
-          Padding(
-            padding: EdgeInsets.only(left: 8.0),
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: SizedBox(
-                width: 180,
-                child: Material(
-                  color: Colors.white,
-                  child: TabBar(
-                    indicator: UnderlineTabIndicator(
-                      borderSide:
-                          BorderSide(width: 2.5, color: FarmusThemeColor.dark),
-                    ),
-                    labelColor: FarmusThemeColor.dark,
-                    unselectedLabelColor: FarmusThemeColor.gray3,
-                    tabs: [
-                      Tab(
-                        child: Text(
-                          "성장일기",
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
-                      Tab(
-                        child: Text(
-                          "재배 결과",
-                          style: TextStyle(
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-          ),
-          Divider(
-            thickness: 1.0,
-            height: 1,
-          ),
-          Expanded(
-            child: TabBarView(
-              children: [
-                Center(child: MyPageFeedList()),
-                Center(child: MyPageFeedList()),
-              ],
-            ),
-          ),
-        ],
-      ),
+    return const PrimaryTabBar(
+      tab: ["성장일기", "재배결과"],
+      tabView: [MyPageFeedList(), MyPageFeedList()],
+      labelStyle: FarmusThemeTextStyle.darkSemiBold15,
+      unselectedLabelStyle: FarmusThemeTextStyle.gray3SemiBold15,
     );
   }
 }


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #160


### 🍠 Summary
TabView의 높이가 각자 다르고 제일 큰 문제는 VegeHistoryTabBar의 TabView가 SingleScrollView로 되어있어서 height문제가 생겼던 것 같습니다. 
해결해보려고 했으나 많은 파일을 수정해야할 것 같아 차선책으로  PrimaryTabBar에 tabViewHeights 속성을 추가하여 재사용 시, 각각 위젯에 해당 속성을 설정할 수 있게 코드를 수정하였습니다. 
또한 VegeHistoryTabBar의 tab label은 font와 색상이 달라 재사용 시 따로 설정할 수 있게 코드 수정하였습니다!

[결론]
tabViewHeights : 따로 설정을 하지 않으면 singlescrollview로 view 받음
labelStyle, unselectedLabelStyle : 위젯 재사용 시 따로 설정 가능, 따로 설정하지 않으면 기존 PrimaryTabBar의 TextStyle을 적용
추가로 혹시 몰라 작은 애뮬레이터로 실행해봤는데 레이아웃 오류는 생기지 않았습니다! 

https://github.com/Mojacknong/Farmus_App/assets/105162858/fea940d3-fa37-4386-9955-53ae998d7385




### 🌽 PR Type
- [ ] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [x] Refactoring
- [ ] Documentation content change
- [x] Other


### 🫛 Other Information
MyPage 확인하다가 추가로 수정해야할 거 보여서 수정했습니다!
