### PR TITLE
[Feat] 미션 인증하기 UI 구현

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
+  - AppAuth (1.7.5):
+    - AppAuth/Core (= 1.7.5)
+    - AppAuth/ExternalUserAgent (= 1.7.5)
+  - AppAuth/Core (1.7.5)
+  - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
   - Firebase/Auth (10.20.0):
     - Firebase/CoreOnly
@@ -17,7 +17,7 @@ PODS:
   - firebase_core (2.25.5):
     - Firebase/CoreOnly (= 10.20.0)
     - Flutter
-  - FirebaseAppCheckInterop (10.21.0)
+  - FirebaseAppCheckInterop (10.25.0)
   - FirebaseAuth (10.20.0):
     - FirebaseAppCheckInterop (~> 10.17)
     - FirebaseCore (~> 10.0)
@@ -29,7 +29,7 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.21.0):
+  - FirebaseCoreInternal (10.25.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - Flutter (1.0.0)
   - flutter_secure_storage (6.0.0):
@@ -38,36 +38,36 @@ PODS:
     - Flutter
     - FlutterMacOS
     - GoogleSignIn (~> 7.0)
-  - GoogleSignIn (7.0.0):
-    - AppAuth (~> 1.5)
-    - GTMAppAuth (< 3.0, >= 1.3)
-    - GTMSessionFetcher/Core (< 4.0, >= 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (7.13.0):
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GoogleUtilities/AppDelegateSwizzler (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (7.13.0):
+  - GoogleUtilities/Environment (7.13.3):
     - GoogleUtilities/Privacy
     - PromisesObjC (< 3.0, >= 1.2)
-  - GoogleUtilities/Logger (7.13.0):
+  - GoogleUtilities/Logger (7.13.3):
     - GoogleUtilities/Environment
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (7.13.0):
+  - GoogleUtilities/Network (7.13.3):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Privacy
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (7.13.0)":
+  - "GoogleUtilities/NSData+zlib (7.13.3)":
     - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (7.13.0)
-  - GoogleUtilities/Reachability (7.13.0):
+  - GoogleUtilities/Privacy (7.13.3)
+  - GoogleUtilities/Reachability (7.13.3):
     - GoogleUtilities/Logger
     - GoogleUtilities/Privacy
-  - GTMAppAuth (2.0.0):
-    - AppAuth/Core (~> 1.6)
-    - GTMSessionFetcher/Core (< 4.0, >= 1.5)
-  - GTMSessionFetcher/Core (3.3.1)
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher/Core (3.4.1)
   - image_picker_ios (0.0.1):
     - Flutter
   - kakao_flutter_sdk_common (1.9.0):
@@ -134,21 +134,21 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
+  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
   Firebase: 10c8cb12fb7ad2ae0c09ffc86cd9c1ab392a0031
   firebase_auth: b237f065b2afc6bd7962124e1cbacdbef31036e6
   firebase_core: c8628c7ce80f79439149549052bff22f6784fbf5
-  FirebaseAppCheckInterop: 69fc7d8f6a1cbfa973efb8d1723651de30d12525
+  FirebaseAppCheckInterop: 5da5ce93e8797a215e3f677fb0654b74e736c8b8
   FirebaseAuth: 9c5c400d2c3055d8ae3a0284944c86fa95d48dac
   FirebaseCore: 28045c1560a2600d284b9c45a904fe322dc890b6
-  FirebaseCoreInternal: 43c1788eaeee9d1b97caaa751af567ce11010d00
+  FirebaseCoreInternal: 910a81992c33715fec9263ca7381d59ab3a750b7
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   google_sign_in_ios: 989eea5abe94af62050782714daf920be883d4a2
-  GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
-  GoogleUtilities: d053d902a8edaa9904e1bd00c37535385b8ed152
-  GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
-  GTMSessionFetcher: 8a1b34ad97ebe6f909fb8b9b77fba99943007556
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
+  GoogleUtilities: ea963c370a38a8069cc5f7ba4ca849a60b6d7d15
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 8000756fc1c19d2e5697b90311f7832d2e33f6cd
   image_picker_ios: 99dfe1854b4fa34d0364e74a78448a0151025425
   kakao_flutter_sdk_common: 6cc350382c723c0ec6faf44e7c68a22b1c48737b
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c

--- a/lib/common/app_bar/delete_app_bar.dart
+++ b/lib/common/app_bar/delete_app_bar.dart
@@ -1,0 +1,29 @@
+import 'package:farmus/common/app_bar/primary_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/svg.dart';
+
+class DeleteAppBar extends ConsumerWidget implements PreferredSizeWidget {
+  const DeleteAppBar({super.key, required this.title, this.actions});
+
+  final String title;
+  final List<Widget>? actions;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PrimaryAppBar(
+      leading: IconButton(
+        onPressed: () {
+          Navigator.pop(context);
+        },
+        icon: SvgPicture.asset("assets/image/ic_close.svg"),
+      ),
+      title: title,
+      centerTitle: false,
+      actions: actions,
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/common/button/primary_color_button.dart
+++ b/lib/common/button/primary_color_button.dart
@@ -8,13 +8,19 @@ class PrimaryColorButton extends ConsumerWidget {
   final String text;
   final VoidCallback onPressed;
   final bool enabled;
+  final double? fontSize;
+  final double? borderRadius;
+  final double? fontPadding;
 
-  const PrimaryColorButton({
-    Key? key,
-    required this.text,
-    required this.onPressed,
-    required this.enabled,
-  }) : super(key: key);
+  const PrimaryColorButton(
+      {Key? key,
+      required this.text,
+      required this.onPressed,
+      required this.enabled,
+      this.fontSize,
+      this.borderRadius,
+      this.fontPadding})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -28,7 +34,9 @@ class PrimaryColorButton extends ConsumerWidget {
         backgroundColor:
             enabled ? FarmusThemeColor.primary : FarmusThemeColor.gray4,
         borderColor: FarmusThemeColor.white,
-        fontSize: 15,
+        borderRadius: borderRadius,
+        fontSize: fontSize ?? 15,
+        fontPadding: fontPadding,
       ),
     );
   }

--- a/lib/common/form/content_input_text_form.dart
+++ b/lib/common/form/content_input_text_form.dart
@@ -1,21 +1,23 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'primary_text_form_field.dart';
 import '../theme/farmus_theme_color.dart';
+import 'primary_text_form_field.dart';
 
 class ContentInputTextForm extends ConsumerWidget {
-  const ContentInputTextForm({super.key, required this.maxLength, required this.nowContent, required this.updateContent});
+  const ContentInputTextForm(
+      {super.key,
+        required this.maxLength,
+        required this.nowContent,
+        this.updateContent});
 
   final int maxLength;
   final String? nowContent;
-  final void Function(String) updateContent;
+  final Function(String?)? updateContent;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var nowLength = nowContent == null
-        ? 0
-        : nowContent?.length;
+    var nowLength = nowContent == null ? 0 : nowContent?.length;
 
     return PrimaryTextFormField(
         maxLength: maxLength,
@@ -31,9 +33,7 @@ class ContentInputTextForm extends ConsumerWidget {
         errorStyle: const TextStyle(
           color: FarmusThemeColor.red,
         ),
-        onChanged: (value) {
-          updateContent(value);
-        },
+        onChanged: (value) => updateContent?.call(value),
         suffix: Column(
           children: [
             Text("$nowLength /$maxLength"),

--- a/lib/common/image_picker/write_image_picker.dart
+++ b/lib/common/image_picker/write_image_picker.dart
@@ -1,35 +1,41 @@
 import 'dart:io';
 
 import 'package:farmus/common/theme/farmus_theme_text_style.dart';
-import 'package:farmus/view_model/vege_diary_write/vege_diary_write_provider.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:image_picker/image_picker.dart';
 
 import '../bottom_sheet/farmus_image_picker.dart';
 import '../theme/farmus_theme_color.dart';
 
-class DiaryImagePicker extends ConsumerStatefulWidget {
-  const DiaryImagePicker({
+class WriteImagePicker extends ConsumerStatefulWidget {
+  const WriteImagePicker({
     Key? key,
     this.nullChild,
     this.boxDecoration,
+    this.imageProvider,
+    required this.updateImage,
+    required this.deleteImage,
   }) : super(key: key);
 
   final Widget? nullChild;
   final BoxDecoration? boxDecoration;
+  final XFile? imageProvider;
+  final Function(XFile?) updateImage;
+  final Function(XFile?) deleteImage;
 
   @override
   ConsumerState createState() => _PrimaryImagePickerState();
 }
 
-class _PrimaryImagePickerState extends ConsumerState<DiaryImagePicker> {
+class _PrimaryImagePickerState extends ConsumerState<WriteImagePicker> {
   @override
   Widget build(BuildContext context) {
     final nullChild = widget.nullChild;
     final boxDecoration = widget.boxDecoration;
 
-    var successImage = ref.watch(vegeDiaryWriteProvider).image;
+    var successImage = widget.imageProvider;
 
     void showActionSheet(BuildContext context) {
       FarmusImagePicker.showActionSheet(
@@ -38,9 +44,7 @@ class _PrimaryImagePickerState extends ConsumerState<DiaryImagePicker> {
           if (value != null) {
             setState(() {
               successImage = value;
-              ref
-                  .read(vegeDiaryWriteProvider.notifier)
-                  .updateImage(successImage);
+              widget.updateImage(successImage);
             });
           }
         },
@@ -94,9 +98,7 @@ class _PrimaryImagePickerState extends ConsumerState<DiaryImagePicker> {
                   onTap: () {
                     (successImage == null)
                         ? showActionSheet(context)
-                        : ref
-                            .read(vegeDiaryWriteProvider.notifier)
-                            .deleteImage();
+                        : widget.deleteImage(successImage);
                   },
                   child: (successImage == null)
                       ? SvgPicture.asset('assets/image/ic_camera.svg',

--- a/lib/common/tab_bar/primary_tab_bar.dart
+++ b/lib/common/tab_bar/primary_tab_bar.dart
@@ -26,7 +26,7 @@ class PrimaryTabBar extends StatelessWidget implements BaseTabBar {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      initialIndex: 1,
+      initialIndex: 0,
       length: tab.length,
       child: Column(
         children: [

--- a/lib/common/theme/farmus_theme_text_style.dart
+++ b/lib/common/theme/farmus_theme_text_style.dart
@@ -165,6 +165,11 @@ class FarmusThemeTextStyle {
     fontWeight: FontWeight.w600,
   );
 
+  static const TextStyle gray2Medium17 = TextStyle(
+    color: FarmusThemeColor.gray2,
+    fontSize: 17,
+  );
+
   static const TextStyle gray2SemiBold17 = TextStyle(
     color: FarmusThemeColor.gray2,
     fontSize: 17,
@@ -230,6 +235,11 @@ class FarmusThemeTextStyle {
   );
 
   // white
+  static const TextStyle whiteMedium10 = TextStyle(
+    color: FarmusThemeColor.white,
+    fontSize: 10,
+  );
+
   static const TextStyle whiteSemiBold15 = TextStyle(
       color: FarmusThemeColor.white, fontSize: 15, fontWeight: FontWeight.w600);
 

--- a/lib/model/mission/mission_write_model.dart
+++ b/lib/model/mission/mission_write_model.dart
@@ -1,0 +1,25 @@
+import 'package:image_picker/image_picker.dart';
+
+class MissionWriteModel {
+  final String? content;
+  final XFile? image;
+  final bool isComplete;
+
+  MissionWriteModel({
+    required this.content,
+    required this.image,
+    required this.isComplete,
+  });
+
+  MissionWriteModel copyWith({
+    String? content,
+    XFile? image,
+    required bool isComplete,
+  }) {
+    return MissionWriteModel(
+      content: content,
+      image: image,
+      isComplete: isComplete,
+    );
+  }
+}

--- a/lib/view/farmclub/component/farmclub_step.dart
+++ b/lib/view/farmclub/component/farmclub_step.dart
@@ -53,7 +53,9 @@ class FarmclubStep extends ConsumerWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (builder) => MissionWriteScreen(),
+                        builder: (builder) => const MissionWriteScreen(
+                          stepNum: 3,
+                        ),
                       ),
                     );
                   },

--- a/lib/view/farmclub/component/farmclub_step.dart
+++ b/lib/view/farmclub/component/farmclub_step.dart
@@ -1,5 +1,5 @@
 import 'package:farmus/common/farmus_picture_fix.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:farmus/view/mission_write/mission_write_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -48,19 +48,29 @@ class FarmclubStep extends ConsumerWidget {
                     ],
                   ),
                 ),
-                Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 20.0, vertical: 12.0),
-                  decoration: ShapeDecoration(
-                    color: FarmusThemeColor.gray6,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30),
+                GestureDetector(
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (builder) => MissionWriteScreen(),
+                      ),
+                    );
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 20.0, vertical: 12.0),
+                    decoration: ShapeDecoration(
+                      color: FarmusThemeColor.gray6,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
                     ),
-                  ),
-                  child: const Center(
-                    child: Text(
-                      '인증하기',
-                      style: FarmusThemeTextStyle.whiteSemiBold15,
+                    child: const Center(
+                      child: Text(
+                        '인증하기',
+                        style: FarmusThemeTextStyle.whiteSemiBold15,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/view/farmclub/component/farmclub_step_tip.dart
+++ b/lib/view/farmclub/component/farmclub_step_tip.dart
@@ -1,52 +1,64 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 
 import '../../../common/theme/farmus_theme_color.dart';
 import '../../../common/theme/farmus_theme_text_style.dart';
+import '../../tip/tip_screen.dart';
 
 class FarmclubStepTip extends ConsumerWidget {
   const FarmclubStepTip({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            SvgPicture.asset(
-              'assets/image/ic_farmclub_mark.svg',
-            ),
-            const SizedBox(
-              width: 8,
-            ),
-            const Text(
-              '도움말',
-              style: FarmusThemeTextStyle.gray2SemiBold13,
-            ),
-            GestureDetector(
-              onTap: () {},
-              child: SvgPicture.asset(
-                'assets/image/ic_right.svg',
-                width: 19,
-                height: 19,
-                colorFilter: const ColorFilter.mode(
-                  FarmusThemeColor.gray2,
-                  BlendMode.srcIn,
-                ),
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => const TipScreen(),
+          ),
+        );
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              SvgPicture.asset(
+                'assets/image/ic_farmclub_mark.svg',
               ),
-            )
-          ],
-        ),
-        const SizedBox(
-          height: 8,
-        ),
-        const Text(
-          '상추 씨앗과 상토, 재배 용기를 준비해주세요',
-          style: FarmusThemeTextStyle.darkMedium15,
-        )
-      ],
+              const SizedBox(
+                width: 8,
+              ),
+              const Text(
+                '도움말',
+                style: FarmusThemeTextStyle.gray2SemiBold13,
+              ),
+              GestureDetector(
+                onTap: () {},
+                child: SvgPicture.asset(
+                  'assets/image/ic_right.svg',
+                  width: 19,
+                  height: 19,
+                  colorFilter: const ColorFilter.mode(
+                    FarmusThemeColor.gray2,
+                    BlendMode.srcIn,
+                  ),
+                ),
+              )
+            ],
+          ),
+          const SizedBox(
+            height: 8,
+          ),
+          const Text(
+            '상추 씨앗과 상토, 재배 용기를 준비해주세요',
+            style: FarmusThemeTextStyle.darkMedium15,
+          )
+        ],
+      ),
     );
   }
 }

--- a/lib/view/mission_feed/mission_feed_screen.dart
+++ b/lib/view/mission_feed/mission_feed_screen.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class MissionFeedScreen extends ConsumerWidget {
+  const MissionFeedScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold();
+  }
+}

--- a/lib/view/mission_write/component/mission_step_info.dart
+++ b/lib/view/mission_write/component/mission_step_info.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../common/theme/farmus_theme_color.dart';
+import '../../../common/theme/farmus_theme_text_style.dart';
+
+class MissionStepInfo extends ConsumerWidget {
+  const MissionStepInfo({super.key, required this.stepNum});
+
+  final int stepNum;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: ShapeDecoration(
+        color: FarmusThemeColor.background,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Step $stepNum',
+            style: FarmusThemeTextStyle.gray2SemiBold13,
+          ),
+          const SizedBox(
+            height: 8.0,
+          ),
+          const Text(
+            '준비물을 챙겨요',
+            style: FarmusThemeTextStyle.darkSemiBold15,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -15,14 +15,18 @@ class MissionWriteScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    bool enabled = ref.watch(missionWriteProvider).isComplete;
+
     return Scaffold(
       appBar: DeleteAppBar(
         title: '인증하기',
         actions: [
           PrimaryColorButton(
             text: '완료',
-            onPressed: () {},
-            enabled: false,
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            enabled: enabled,
             borderRadius: 20,
             fontSize: 13,
             fontPadding: 0,
@@ -48,7 +52,7 @@ class MissionWriteScreen extends ConsumerWidget {
                 updateImage: (value) =>
                     ref.read(missionWriteProvider.notifier).updateImage(value),
                 deleteImage: (value) =>
-                  ref.read(missionWriteProvider.notifier).deleteImage(),
+                    ref.read(missionWriteProvider.notifier).deleteImage(),
               ),
             ),
             Padding(

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -1,10 +1,15 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
 import 'package:farmus/common/button/primary_color_button.dart';
+import 'package:farmus/common/theme/farmus_theme_color.dart';
+import 'package:farmus/common/theme/farmus_theme_text_style.dart';
+import 'package:farmus/view/mission_write/component/mission_step_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class MissionWriteScreen extends ConsumerWidget {
-  const MissionWriteScreen({super.key});
+  const MissionWriteScreen({super.key, required this.stepNum});
+
+  final int stepNum;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -12,12 +17,26 @@ class MissionWriteScreen extends ConsumerWidget {
       appBar: DeleteAppBar(
         title: '인증하기',
         actions: [
-          PrimaryColorButton(text: '완료', onPressed: () {}, enabled: false, fontSize: 13, fontPadding: 0,)
+          PrimaryColorButton(
+            text: '완료',
+            onPressed: () {},
+            enabled: false,
+            borderRadius: 20,
+            fontSize: 13,
+            fontPadding: 0,
+          )
         ],
       ),
-      body: const SingleChildScrollView(
+      body: SingleChildScrollView(
         child: Column(
-          children: [],
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: MissionStepInfo(
+                stepNum: stepNum,
+              ),
+            )
+          ],
         ),
       ),
     );

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -5,6 +5,7 @@ import 'package:farmus/view_model/mission_write/mission_write_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../common/dialog/check_dialog.dart';
 import '../../common/form/content_input_text_form.dart';
 import '../../common/image_picker/write_image_picker.dart';
 
@@ -25,6 +26,17 @@ class MissionWriteScreen extends ConsumerWidget {
             text: '완료',
             onPressed: () {
               Navigator.pop(context);
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  Future.delayed(const Duration(seconds: 2), () {
+                    Navigator.of(context).pop();
+                  });
+                  return CheckDialog(
+                    text: "Step $stepNum 미션을 인증했어요",
+                  );
+                },
+              );
             },
             enabled: enabled,
             borderRadius: 20,

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -1,0 +1,25 @@
+import 'package:farmus/common/app_bar/delete_app_bar.dart';
+import 'package:farmus/common/button/primary_color_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class MissionWriteScreen extends ConsumerWidget {
+  const MissionWriteScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: DeleteAppBar(
+        title: '인증하기',
+        actions: [
+          PrimaryColorButton(text: '완료', onPressed: () {}, enabled: false, fontSize: 13, fontPadding: 0,)
+        ],
+      ),
+      body: const SingleChildScrollView(
+        child: Column(
+          children: [],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -1,10 +1,12 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
 import 'package:farmus/common/button/primary_color_button.dart';
-import 'package:farmus/common/theme/farmus_theme_color.dart';
-import 'package:farmus/common/theme/farmus_theme_text_style.dart';
 import 'package:farmus/view/mission_write/component/mission_step_info.dart';
+import 'package:farmus/view_model/mission_write/mission_write_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../common/form/content_input_text_form.dart';
+import '../../common/image_picker/write_image_picker.dart';
 
 class MissionWriteScreen extends ConsumerWidget {
   const MissionWriteScreen({super.key, required this.stepNum});
@@ -35,7 +37,30 @@ class MissionWriteScreen extends ConsumerWidget {
               child: MissionStepInfo(
                 stepNum: stepNum,
               ),
-            )
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 48.0,
+                vertical: 16.0,
+              ),
+              child: WriteImagePicker(
+                imageProvider: ref.watch(missionWriteProvider).image,
+                updateImage: (value) =>
+                    ref.read(missionWriteProvider.notifier).updateImage(value),
+                deleteImage: (value) =>
+                  ref.read(missionWriteProvider.notifier).deleteImage(),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ContentInputTextForm(
+                maxLength: 300,
+                nowContent: ref.watch(missionWriteProvider).content,
+                updateContent: (value) => ref
+                    .watch(missionWriteProvider.notifier)
+                    .updateContent(value),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/view/tip/component/tip_expand_card.dart
+++ b/lib/view/tip/component/tip_expand_card.dart
@@ -9,80 +9,88 @@ class TipExpandCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Card(
-      child: ExpansionTile(
-        leading: Container(
-          width: 40,
-          height: 40,
-          decoration: ShapeDecoration(
-            color: FarmusThemeColor.background,
-            image: null,
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(30),
+    return Container(
+      decoration: ShapeDecoration(
+        color: FarmusThemeColor.background,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(20),
+        ),
+      ),
+      child: Theme(
+        data: Theme.of(context).copyWith(dividerColor: Colors.transparent),
+        child: ExpansionTile(
+          leading: Container(
+            width: 40,
+            height: 40,
+            decoration: ShapeDecoration(
+              color: FarmusThemeColor.black,
+              image: null,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(30),
+              ),
             ),
           ),
-        ),
-        title: const Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '준비물',
-              style: FarmusThemeTextStyle.gray2Medium13,
+          title: const Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '준비물',
+                style: FarmusThemeTextStyle.gray2Medium13,
+              ),
+              SizedBox(
+                height: 8.0,
+              ),
+              Text(
+                '흙대파, 상토, 재사용 흙, 재배 용기',
+                style: FarmusThemeTextStyle.darkMedium15,
+              ),
+            ],
+          ),
+          children: const [
+            ListTile(
+              leading: SizedBox(
+                width: 40,
+              ),
+              title: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '고르는 법',
+                    style: FarmusThemeTextStyle.gray2Medium13,
+                  ),
+                  SizedBox(
+                    height: 8.0,
+                  ),
+                  Text(
+                    '뿌리가 튼튼하게 달려있어요\n너무 가는 것은 순이 여러 번 나오지 못해요\n너무 굵은 것은 맛이 덜해요',
+                    style: FarmusThemeTextStyle.darkMedium15,
+                  ),
+                ],
+              ),
             ),
-            SizedBox(
-              height: 8.0,
-            ),
-            Text(
-              '흙대파, 상토, 재사용 흙, 재배 용기',
-              style: FarmusThemeTextStyle.darkMedium15,
+            ListTile(
+              leading: SizedBox(
+                width: 40,
+              ),
+              title: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '특징',
+                    style: FarmusThemeTextStyle.gray2Medium13,
+                  ),
+                  SizedBox(
+                    height: 8.0,
+                  ),
+                  Text(
+                    '심고 일주일만 기다리면 먹을 수 있어요\n장마철에 키우기 어려워요',
+                    style: FarmusThemeTextStyle.darkMedium15,
+                  ),
+                ],
+              ),
             ),
           ],
         ),
-        backgroundColor: FarmusThemeColor.white,
-        children: const [
-          ListTile(
-            leading: SizedBox(
-              width: 40,
-            ),
-            title: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '고르는 법',
-                  style: FarmusThemeTextStyle.gray2Medium13,
-                ),
-                SizedBox(
-                  height: 8.0,
-                ),
-                Text(
-                  '뿌리가 튼튼하게 달려있어요\n너무 가는 것은 순이 여러 번 나오지 못해요\n너무 굵은 것은 맛이 덜해요',
-                  style: FarmusThemeTextStyle.darkMedium15,
-                ),
-              ],
-            ),
-          ),
-          ListTile(
-            leading: SizedBox(
-              width: 40,
-            ),
-            title: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '특징',
-                  style: FarmusThemeTextStyle.gray2Medium13,
-                ),
-                SizedBox(
-                  height: 8.0,
-                ),
-                Text(
-                  '심고 일주일만 기다리면 먹을 수 있어요\n장마철에 키우기 어려워요',
-                  style: FarmusThemeTextStyle.darkMedium15,
-                ),
-              ],
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/view/tip/component/tip_expand_card.dart
+++ b/lib/view/tip/component/tip_expand_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../common/theme/farmus_theme_color.dart';
+import '../../../common/theme/farmus_theme_text_style.dart';
+
+class TipExpandCard extends ConsumerWidget {
+  const TipExpandCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Card(
+      child: ExpansionTile(
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: ShapeDecoration(
+            color: FarmusThemeColor.background,
+            image: null,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(30),
+            ),
+          ),
+        ),
+        title: const Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '준비물',
+              style: FarmusThemeTextStyle.gray2Medium13,
+            ),
+            SizedBox(
+              height: 8.0,
+            ),
+            Text(
+              '흙대파, 상토, 재사용 흙, 재배 용기',
+              style: FarmusThemeTextStyle.darkMedium15,
+            ),
+          ],
+        ),
+        backgroundColor: FarmusThemeColor.white,
+        children: const [
+          ListTile(
+            leading: SizedBox(
+              width: 40,
+            ),
+            title: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '고르는 법',
+                  style: FarmusThemeTextStyle.gray2Medium13,
+                ),
+                SizedBox(
+                  height: 8.0,
+                ),
+                Text(
+                  '뿌리가 튼튼하게 달려있어요\n너무 가는 것은 순이 여러 번 나오지 못해요\n너무 굵은 것은 맛이 덜해요',
+                  style: FarmusThemeTextStyle.darkMedium15,
+                ),
+              ],
+            ),
+          ),
+          ListTile(
+            leading: SizedBox(
+              width: 40,
+            ),
+            title: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  '특징',
+                  style: FarmusThemeTextStyle.gray2Medium13,
+                ),
+                SizedBox(
+                  height: 8.0,
+                ),
+                Text(
+                  '심고 일주일만 기다리면 먹을 수 있어요\n장마철에 키우기 어려워요',
+                  style: FarmusThemeTextStyle.darkMedium15,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/tip/component/tip_step_text.dart
+++ b/lib/view/tip/component/tip_step_text.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../common/theme/farmus_theme_color.dart';
+import '../../../common/theme/farmus_theme_text_style.dart';
+
+class TipStepText extends ConsumerWidget {
+  final int stepIndex;
+  final String stepTitle;
+  final Map<int, String> detailStep;
+
+  const TipStepText({
+    Key? key,
+    required this.stepIndex,
+    required this.stepTitle,
+    required this.detailStep,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Text(
+              'Step $stepIndex',
+              style: FarmusThemeTextStyle.gray2Medium17,
+            ),
+            const SizedBox(
+              width: 8,
+            ),
+            Text(
+              stepTitle,
+              style: FarmusThemeTextStyle.darkSemiBold17,
+            )
+          ],
+        ),
+        const SizedBox(
+          height: 16.0,
+        ),
+        for (final entry in detailStep.entries)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8.0),
+            child: Row(
+              children: [
+                Container(
+                  width: 16,
+                  height: 16,
+                  decoration: ShapeDecoration(
+                    color: FarmusThemeColor.gray2,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(21),
+                    ),
+                  ),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Text(
+                        '${entry.key}',
+                        style: FarmusThemeTextStyle.whiteMedium10,
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(
+                  width: 8.0,
+                ),
+                Text(
+                  entry.value,
+                  style: FarmusThemeTextStyle.darkMedium15,
+                ),
+              ],
+            ),
+          ),
+        const Divider(
+          color: FarmusThemeColor.gray4,
+        ),
+        const SizedBox(
+          height: 8,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view/tip/tip_screen.dart
+++ b/lib/view/tip/tip_screen.dart
@@ -1,0 +1,19 @@
+import 'package:farmus/common/app_bar/delete_app_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class TipScreen extends ConsumerWidget {
+  const TipScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return const Scaffold(
+      appBar: DeleteAppBar(
+        title: '도움말',
+      ),
+      body: Column(
+        children: [],
+      ),
+    );
+  }
+}

--- a/lib/view/tip/tip_screen.dart
+++ b/lib/view/tip/tip_screen.dart
@@ -1,9 +1,10 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
+import 'package:farmus/view/tip/component/tip_expand_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../common/theme/farmus_theme_color.dart';
 import '../../common/theme/farmus_theme_text_style.dart';
+import 'component/tip_step_text.dart';
 
 class TipScreen extends ConsumerWidget {
   const TipScreen({super.key});
@@ -24,80 +25,23 @@ class TipScreen extends ConsumerWidget {
               style: FarmusThemeTextStyle.darkSemiBold21,
             ),
           ),
-          Card(
-            child: ExpansionTile(
-              leading: Container(
-                width: 40,
-                height: 40,
-                decoration: ShapeDecoration(
-                  color: FarmusThemeColor.background,
-                  image: null,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(30),
+          const TipExpandCard(),
+          const SizedBox(
+            height: 16,
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: 5,
+              itemBuilder: (context, index) {
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: TipStepText(
+                    stepIndex: index + 1,
+                    stepTitle: '대파를 심어요',
+                    detailStep: {1: '1번', 2:'2번', 3:'3번'},
                   ),
-                ),
-              ),
-              title: const Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    '준비물',
-                    style: FarmusThemeTextStyle.gray2Medium13,
-                  ),
-                  SizedBox(
-                    height: 8.0,
-                  ),
-                  Text(
-                    '흙대파, 상토, 재사용 흙, 재배 용기',
-                    style: FarmusThemeTextStyle.darkMedium15,
-                  ),
-                ],
-              ),
-              backgroundColor: FarmusThemeColor.white,
-              children: const [
-                ListTile(
-                  leading: SizedBox(
-                    width: 40,
-                  ),
-                  title: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '고르는 법',
-                        style: FarmusThemeTextStyle.gray2Medium13,
-                      ),
-                      SizedBox(
-                        height: 8.0,
-                      ),
-                      Text(
-                        '뿌리가 튼튼하게 달려있어요\n너무 가는 것은 순이 여러 번 나오지 못해요\n너무 굵은 것은 맛이 덜해요',
-                        style: FarmusThemeTextStyle.darkMedium15,
-                      ),
-                    ],
-                  ),
-                ),
-                ListTile(
-                  leading: SizedBox(
-                    width: 40,
-                  ),
-                  title: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        '특징',
-                        style: FarmusThemeTextStyle.gray2Medium13,
-                      ),
-                      SizedBox(
-                        height: 8.0,
-                      ),
-                      Text(
-                        '심고 일주일만 기다리면 먹을 수 있어요\n장마철에 키우기 어려워요',
-                        style: FarmusThemeTextStyle.darkMedium15,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
+                );
+              },
             ),
           ),
         ],

--- a/lib/view/tip/tip_screen.dart
+++ b/lib/view/tip/tip_screen.dart
@@ -2,17 +2,105 @@ import 'package:farmus/common/app_bar/delete_app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../common/theme/farmus_theme_color.dart';
+import '../../common/theme/farmus_theme_text_style.dart';
+
 class TipScreen extends ConsumerWidget {
   const TipScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(
-      appBar: DeleteAppBar(
+    return Scaffold(
+      appBar: const DeleteAppBar(
         title: '도움말',
       ),
       body: Column(
-        children: [],
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: Text(
+              '대파 키우기',
+              style: FarmusThemeTextStyle.darkSemiBold21,
+            ),
+          ),
+          Card(
+            child: ExpansionTile(
+              leading: Container(
+                width: 40,
+                height: 40,
+                decoration: ShapeDecoration(
+                  color: FarmusThemeColor.background,
+                  image: null,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+              ),
+              title: const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '준비물',
+                    style: FarmusThemeTextStyle.gray2Medium13,
+                  ),
+                  SizedBox(
+                    height: 8.0,
+                  ),
+                  Text(
+                    '흙대파, 상토, 재사용 흙, 재배 용기',
+                    style: FarmusThemeTextStyle.darkMedium15,
+                  ),
+                ],
+              ),
+              backgroundColor: FarmusThemeColor.white,
+              children: const [
+                ListTile(
+                  leading: SizedBox(
+                    width: 40,
+                  ),
+                  title: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '고르는 법',
+                        style: FarmusThemeTextStyle.gray2Medium13,
+                      ),
+                      SizedBox(
+                        height: 8.0,
+                      ),
+                      Text(
+                        '뿌리가 튼튼하게 달려있어요\n너무 가는 것은 순이 여러 번 나오지 못해요\n너무 굵은 것은 맛이 덜해요',
+                        style: FarmusThemeTextStyle.darkMedium15,
+                      ),
+                    ],
+                  ),
+                ),
+                ListTile(
+                  leading: SizedBox(
+                    width: 40,
+                  ),
+                  title: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '특징',
+                        style: FarmusThemeTextStyle.gray2Medium13,
+                      ),
+                      SizedBox(
+                        height: 8.0,
+                      ),
+                      Text(
+                        '심고 일주일만 기다리면 먹을 수 있어요\n장마철에 키우기 어려워요',
+                        style: FarmusThemeTextStyle.darkMedium15,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/view/tip/tip_screen.dart
+++ b/lib/view/tip/tip_screen.dart
@@ -15,22 +15,27 @@ class TipScreen extends ConsumerWidget {
       appBar: const DeleteAppBar(
         title: '도움말',
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Padding(
-            padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
-            child: Text(
-              '대파 키우기',
-              style: FarmusThemeTextStyle.darkSemiBold21,
+      body: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+              child: Text(
+                '대파 키우기',
+                style: FarmusThemeTextStyle.darkSemiBold21,
+              ),
             ),
-          ),
-          const TipExpandCard(),
-          const SizedBox(
-            height: 16,
-          ),
-          Expanded(
-            child: ListView.builder(
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: TipExpandCard(),
+            ),
+            const SizedBox(
+              height: 32.0,
+            ),
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
               itemCount: 5,
               itemBuilder: (context, index) {
                 return Padding(
@@ -38,13 +43,13 @@ class TipScreen extends ConsumerWidget {
                   child: TipStepText(
                     stepIndex: index + 1,
                     stepTitle: '대파를 심어요',
-                    detailStep: {1: '1번', 2:'2번', 3:'3번'},
+                    detailStep: const {1: '1번', 2: '2번', 3: '3번'},
                   ),
                 );
               },
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/vege_delete/component/vege_delete_success.dart
+++ b/lib/view/vege_delete/component/vege_delete_success.dart
@@ -40,7 +40,7 @@ class _VegeDeleteSuccessState extends ConsumerState<VegeDeleteSuccess> {
         ContentInputTextForm(
           maxLength: 50,
           nowContent: ref.watch(vegeDeleteSuccessProvider).content,
-          updateContent: (value) => ref.watch(vegeDeleteSuccessProvider.notifier).updateContent(value),
+          updateContent: (value) => ref.watch(vegeDeleteSuccessProvider.notifier).updateContent(value!),
         ),
       ],
     );

--- a/lib/view/vege_delete/vege_delete_screen.dart
+++ b/lib/view/vege_delete/vege_delete_screen.dart
@@ -127,6 +127,7 @@ class VegeDeleteScreen extends ConsumerWidget {
                   Expanded(
                     child: PrimaryColorButton(
                       text: nextButtonText,
+                      fontSize: 15,
                       onPressed: onPressed!,
                       enabled: enabled,
                     ),

--- a/lib/view/vege_diary_write/vege_diary_write_screen.dart
+++ b/lib/view/vege_diary_write/vege_diary_write_screen.dart
@@ -1,3 +1,4 @@
+import 'package:farmus/common/app_bar/delete_app_bar.dart';
 import 'package:farmus/common/app_bar/primary_app_bar.dart';
 import 'package:farmus/common/button/primary_button.dart';
 import 'package:farmus/common/image_picker/diary_image_picker.dart';
@@ -19,15 +20,8 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
     bool enabled = ref.watch(vegeDiaryWriteProvider).isComplete;
 
     return Scaffold(
-      appBar: PrimaryAppBar(
-        leading: IconButton(
-          onPressed: () {
-            Navigator.pop(context);
-          },
-          icon: SvgPicture.asset("assets/image/ic_close.svg"),
-        ),
+      appBar: DeleteAppBar(
         title: "일기 쓰기",
-        centerTitle: false,
         actions: [
           PrimaryButton(
             enabled: enabled,

--- a/lib/view/vege_diary_write/vege_diary_write_screen.dart
+++ b/lib/view/vege_diary_write/vege_diary_write_screen.dart
@@ -7,6 +7,7 @@ import 'package:farmus/view_model/vege_diary_write/vege_diary_write_provider.dar
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../common/dialog/check_dialog.dart';
 import '../../common/form/content_input_text_form.dart';
 import '../../common/theme/farmus_theme_color.dart';
 
@@ -27,6 +28,17 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
             fontSize: 13,
             onPressed: () {
               Navigator.pop(context);
+              showDialog(
+                context: context,
+                builder: (BuildContext context) {
+                  Future.delayed(const Duration(seconds: 2), () {
+                    Navigator.of(context).pop();
+                  });
+                  return const CheckDialog(
+                    text: "일기가 업로드 되었어요",
+                  );
+                },
+              );
             },
             text: '완료',
             fontPadding: 0,
@@ -49,10 +61,12 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
                     ),
                     child: WriteImagePicker(
                       imageProvider: ref.watch(vegeDiaryWriteProvider).image,
-                      updateImage: (value) =>
-                          ref.read(vegeDiaryWriteProvider.notifier).updateImage(value),
-                      deleteImage: (value) =>
-                          ref.read(vegeDiaryWriteProvider.notifier).deleteImage(),
+                      updateImage: (value) => ref
+                          .read(vegeDiaryWriteProvider.notifier)
+                          .updateImage(value),
+                      deleteImage: (value) => ref
+                          .read(vegeDiaryWriteProvider.notifier)
+                          .deleteImage(),
                     ),
                   ),
                   const SizedBox(
@@ -65,7 +79,7 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
                       nowContent: ref.watch(vegeDiaryWriteProvider).content,
                       updateContent: (value) => ref
                           .watch(vegeDiaryWriteProvider.notifier)
-                          .updateContent(value),
+                          .updateContent(value!),
                     ),
                   ),
                   const VegeDiaryWriteState(),

--- a/lib/view/vege_diary_write/vege_diary_write_screen.dart
+++ b/lib/view/vege_diary_write/vege_diary_write_screen.dart
@@ -1,6 +1,7 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
 import 'package:farmus/common/app_bar/primary_app_bar.dart';
 import 'package:farmus/common/button/primary_button.dart';
+import 'package:farmus/common/button/primary_color_button.dart';
 import 'package:farmus/common/image_picker/diary_image_picker.dart';
 import 'package:farmus/view/vege_diary_write/component/vege_diary_write_bottom.dart';
 import 'package:farmus/view/vege_diary_write/component/vege_diary_write_state.dart';
@@ -23,13 +24,8 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
       appBar: DeleteAppBar(
         title: "일기 쓰기",
         actions: [
-          PrimaryButton(
+          PrimaryColorButton(
             enabled: enabled,
-            textColor:
-                enabled ? FarmusThemeColor.white : FarmusThemeColor.white,
-            backgroundColor:
-                enabled ? FarmusThemeColor.primary : FarmusThemeColor.gray3,
-            borderColor: FarmusThemeColor.white,
             borderRadius: 20,
             fontSize: 13,
             onPressed: () {

--- a/lib/view/vege_diary_write/vege_diary_write_screen.dart
+++ b/lib/view/vege_diary_write/vege_diary_write_screen.dart
@@ -1,14 +1,11 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
-import 'package:farmus/common/app_bar/primary_app_bar.dart';
-import 'package:farmus/common/button/primary_button.dart';
 import 'package:farmus/common/button/primary_color_button.dart';
-import 'package:farmus/common/image_picker/diary_image_picker.dart';
+import 'package:farmus/common/image_picker/write_image_picker.dart';
 import 'package:farmus/view/vege_diary_write/component/vege_diary_write_bottom.dart';
 import 'package:farmus/view/vege_diary_write/component/vege_diary_write_state.dart';
 import 'package:farmus/view_model/vege_diary_write/vege_diary_write_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../common/form/content_input_text_form.dart';
 import '../../common/theme/farmus_theme_color.dart';
@@ -45,12 +42,18 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
             child: SingleChildScrollView(
               child: Column(
                 children: [
-                  const Padding(
-                    padding: EdgeInsets.symmetric(
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
                       horizontal: 48.0,
                       vertical: 8.0,
                     ),
-                    child: DiaryImagePicker(),
+                    child: WriteImagePicker(
+                      imageProvider: ref.watch(vegeDiaryWriteProvider).image,
+                      updateImage: (value) =>
+                          ref.read(vegeDiaryWriteProvider.notifier).updateImage(value),
+                      deleteImage: (value) =>
+                          ref.read(vegeDiaryWriteProvider.notifier).deleteImage(),
+                    ),
                   ),
                   const SizedBox(
                     height: 16,

--- a/lib/view_model/mission_write/mission_write_provider.dart
+++ b/lib/view_model/mission_write/mission_write_provider.dart
@@ -1,0 +1,8 @@
+import 'package:farmus/model/mission/mission_write_model.dart';
+import 'package:farmus/view_model/mission_write/notifier/mission_write_notifier.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final missionWriteProvider =
+    StateNotifierProvider.autoDispose<MissionWriteNotifier, MissionWriteModel>((ref) {
+  return MissionWriteNotifier();
+});

--- a/lib/view_model/mission_write/notifier/mission_write_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_write_notifier.dart
@@ -1,0 +1,71 @@
+import 'package:farmus/model/mission/mission_write_model.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+class MissionWriteNotifier extends StateNotifier<MissionWriteModel> {
+  MissionWriteNotifier()
+      : super(MissionWriteModel(
+          content: null,
+          image: null,
+          isComplete: false,
+        ));
+
+  bool _isVegeComplete = false;
+
+  bool get isVegeComplete => _isVegeComplete;
+
+  void updateImage(XFile? image) {
+    if (state.content != null &&
+        state.content!.isNotEmpty &&
+        image != null &&
+        image.path.isNotEmpty &&
+        state.content!.isNotEmpty) {
+      _isVegeComplete = true;
+    } else {
+      _isVegeComplete = false;
+    }
+
+    state = state.copyWith(
+      content: state.content,
+      image: image,
+      isComplete: isVegeComplete,
+    );
+  }
+
+  void updateContent(String content) {
+    if (content.isNotEmpty &&
+        state.image != null &&
+        state.image!.path.isNotEmpty &&
+        state.content!.isNotEmpty) {
+      _isVegeComplete = true;
+    } else {
+      _isVegeComplete = false;
+    }
+
+    state = state.copyWith(
+      content: content,
+      image: state.image,
+      isComplete: isVegeComplete,
+    );
+  }
+
+  void deleteImage() {
+    state = state.copyWith(
+      content: state.content,
+      image: null,
+      isComplete: false,
+    );
+  }
+
+  void checkVegeComplete(String? content, XFile? image) {
+    if (state.content != null &&
+        state.content!.isNotEmpty &&
+        state.image != null &&
+        state.image!.path.isNotEmpty &&
+        state.content!.isNotEmpty) {
+      _isVegeComplete = true;
+    } else {
+      _isVegeComplete = false;
+    }
+  }
+}

--- a/lib/view_model/mission_write/notifier/mission_write_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_write_notifier.dart
@@ -5,47 +5,48 @@ import 'package:image_picker/image_picker.dart';
 class MissionWriteNotifier extends StateNotifier<MissionWriteModel> {
   MissionWriteNotifier()
       : super(MissionWriteModel(
-          content: null,
-          image: null,
-          isComplete: false,
-        ));
+    content: null,
+    image: null,
+    isComplete: false,
+  ));
 
-  bool _isVegeComplete = false;
+  bool _isComplete = false;
 
-  bool get isVegeComplete => _isVegeComplete;
+  bool get isComplete => _isComplete;
 
   void updateImage(XFile? image) {
     if (state.content != null &&
         state.content!.isNotEmpty &&
         image != null &&
-        image.path.isNotEmpty &&
-        state.content!.isNotEmpty) {
-      _isVegeComplete = true;
+        image.path.isNotEmpty) {
+      _isComplete = true;
     } else {
-      _isVegeComplete = false;
+      _isComplete = false;
     }
 
     state = state.copyWith(
       content: state.content,
       image: image,
-      isComplete: isVegeComplete,
+      isComplete: _isComplete,
     );
   }
 
-  void updateContent(String content) {
+  void updateContent(String? content) {
+    if (content == null) {
+      return;
+    }
     if (content.isNotEmpty &&
         state.image != null &&
-        state.image!.path.isNotEmpty &&
-        state.content!.isNotEmpty) {
-      _isVegeComplete = true;
+        state.image!.path.isNotEmpty) {
+      _isComplete = true;
     } else {
-      _isVegeComplete = false;
+      _isComplete = false;
     }
 
     state = state.copyWith(
       content: content,
       image: state.image,
-      isComplete: isVegeComplete,
+      isComplete: _isComplete,
     );
   }
 
@@ -57,15 +58,14 @@ class MissionWriteNotifier extends StateNotifier<MissionWriteModel> {
     );
   }
 
-  void checkVegeComplete(String? content, XFile? image) {
-    if (state.content != null &&
-        state.content!.isNotEmpty &&
-        state.image != null &&
-        state.image!.path.isNotEmpty &&
-        state.content!.isNotEmpty) {
-      _isVegeComplete = true;
+  void checkComplete(String? content, XFile? image) {
+    if (content != null &&
+        content.isNotEmpty &&
+        image != null &&
+        image.path.isNotEmpty) {
+      _isComplete = true;
     } else {
-      _isVegeComplete = false;
+      _isComplete = false;
     }
   }
 }

--- a/lib/view_model/vege_diary_write/notifier/vege_diary_write_notifier.dart
+++ b/lib/view_model/vege_diary_write/notifier/vege_diary_write_notifier.dart
@@ -21,8 +21,7 @@ class VegeDiaryWriteNotifier extends StateNotifier<VegeDiaryWriteModel> {
         state.content!.isNotEmpty &&
         image != null &&
         image.path.isNotEmpty &&
-        state.vegeState != null &&
-        state.content!.isNotEmpty) {
+        state.vegeState != null) {
       _isVegeComplete = true;
     } else {
       _isVegeComplete = false;
@@ -36,7 +35,10 @@ class VegeDiaryWriteNotifier extends StateNotifier<VegeDiaryWriteModel> {
     );
   }
 
-  void updateContent(String content) {
+  void updateContent(String? content) {
+    if (content == null) {
+      return;
+    }
     if (content.isNotEmpty &&
         state.image != null &&
         state.image!.path.isNotEmpty &&
@@ -88,8 +90,7 @@ class VegeDiaryWriteNotifier extends StateNotifier<VegeDiaryWriteModel> {
         state.content!.isNotEmpty &&
         state.image != null &&
         state.image!.path.isNotEmpty &&
-        state.vegeState != null &&
-        state.content!.isNotEmpty) {
+        state.vegeState != null) {
       _isVegeComplete = true;
     } else {
       _isVegeComplete = false;


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #169 


### 🍠 Summary

https://github.com/Mojacknong/Farmus_App/assets/97820109/ecb231d4-566e-49e8-b813-83fca7595748


- [ ] 앱 바를 구현하면서, 일기쓰기 앱 바와 통일하였습니다. 일기쓰기 앱 바의 PrimaryButton을 PrimaryColorButton으로 바꿔서 enable의 컬러 코드를 다시 작성하지 않아도 되게끔 구현하였습니다
- [ ] 일기쓰기 UI를 거의 재사용 하려다 보니, VegeWriteImagePicker를 WriteImagePicker로 바꾸었습니다. 어떤 provider를 사용하는지, 선언할 때 같이 명시해주면 됩니다. 해당 이미지 피커로 글쓰기에서 사진 선택 구현 할 때 재사용하시면 됩니다! 300글자 제한의 내용 입력 컴포넌트도 마찬가지 입니다!

- [ ] 텍스트 필드 입력시 null 값 오류가 발생해서 해당 에러를 해결했습니다 (머리 아팠음 ㅠㅠ)
- [ ] 다이어로그 추가 - 일기 쓰기, 미션 인증

### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
다이어로그.....깜빡했다 추가하겠습니당

+ 추가 완!