### PR TITLE
[Refactor] 팜클럽 가입하기 데이터 최신화 및 화면 이동

### DIFF
--- a/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
+++ b/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
@@ -10,6 +10,7 @@ import 'package:flutter_svg/svg.dart';
 
 import '../../view/farmclub/component/farmclub_change_bottom_sheet_content.dart';
 import '../../view/farmclub/component/farmclub_exit_bottom_sheet_content.dart';
+import '../../view/main/main_screen.dart';
 import '../../view/sign_in/sign_in_screen.dart';
 import '../theme/farmus_theme_color.dart';
 
@@ -66,6 +67,7 @@ void showFarmclubSignupBottomSheet(
         subTitle: "",
         title: title,
         onPressed: () {
+          Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context) => const MainScreen(selectedIndex: 1,)), (route) => false);
           showDialog(
             context: context,
             builder: (BuildContext context) {

--- a/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
+++ b/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
@@ -64,7 +64,7 @@ void showFarmclubSignupBottomSheet(
       return FarmclubSignUpBottomSheetContent(
         infoId: myVeggieInfoId,
         id: farmClubId,
-        subTitle: "",
+        subTitle: " ",
         title: title,
         onPressed: () {
           Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context) => const MainScreen(selectedIndex: 1,)), (route) => false);

--- a/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
+++ b/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
@@ -64,7 +64,7 @@ void showFarmclubSignupBottomSheet(
       return FarmclubSignUpBottomSheetContent(
         infoId: myVeggieInfoId,
         id: farmClubId,
-        subTitle: " ",
+        subTitle: "",
         title: title,
         onPressed: () {
           Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context) => const MainScreen(selectedIndex: 1,)), (route) => false);

--- a/lib/view/farmclub_sign_up/component/farmclub_sign_up_bottom_sheet_content.dart
+++ b/lib/view/farmclub_sign_up/component/farmclub_sign_up_bottom_sheet_content.dart
@@ -91,7 +91,7 @@ class FarmclubSignUpBottomSheetContent extends ConsumerWidget {
                   right: 0,
                   bottom: 0,
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 30),
                     child: BottomBackgroundDividerButton(
                       button: SizedBox(
                         width: double.infinity,

--- a/lib/view/farmclub_sign_up/component/farmclub_sign_up_bottom_sheet_content.dart
+++ b/lib/view/farmclub_sign_up/component/farmclub_sign_up_bottom_sheet_content.dart
@@ -91,7 +91,7 @@ class FarmclubSignUpBottomSheetContent extends ConsumerWidget {
                   right: 0,
                   bottom: 0,
                   child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
                     child: BottomBackgroundDividerButton(
                       button: SizedBox(
                         width: double.infinity,

--- a/lib/view/farmclub_sign_up/component/farmclub_sign_up_button.dart
+++ b/lib/view/farmclub_sign_up/component/farmclub_sign_up_button.dart
@@ -3,6 +3,9 @@ import 'package:farmus/common/button/primary_color_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../farmclub/farmclub_screen.dart';
+import '../../main/main_screen.dart';
+
 class FarmclubSignUpButton extends ConsumerWidget {
   const FarmclubSignUpButton(
       {super.key,
@@ -26,7 +29,8 @@ class FarmclubSignUpButton extends ConsumerWidget {
           onPressed: () {
             showFarmclubSignupBottomSheet(
                 id, myVeggieInfoId, context, ref, "팜클럽 가입");
-          },
+                },
+
         ),
       ),
     );

--- a/lib/view/farmclub_sign_up/component/farmclub_sign_up_button.dart
+++ b/lib/view/farmclub_sign_up/component/farmclub_sign_up_button.dart
@@ -18,7 +18,7 @@ class FarmclubSignUpButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(8, 4, 8, 32.0),
+      padding: const EdgeInsets.fromLTRB(8, 4, 8, 30.0),
       child: SizedBox(
         width: double.infinity,
         child: PrimaryColorButton(

--- a/lib/view/farmclub_sign_up/farmclub_sign_up_screen.dart
+++ b/lib/view/farmclub_sign_up/farmclub_sign_up_screen.dart
@@ -115,7 +115,7 @@ class FarmclubSignUpScreen extends ConsumerWidget {
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stack) =>
-          Center(child: Text('Failed to load data: $error')),
+          Center(child: Text('Failed to load : $error')),
     );
   }
 }

--- a/lib/view/farmclub_sign_up/farmclub_sign_up_screen.dart
+++ b/lib/view/farmclub_sign_up/farmclub_sign_up_screen.dart
@@ -2,6 +2,7 @@ import 'package:farmus/common/app_bar/back_left_title_app_bar.dart';
 import 'package:farmus/common/button/bottom_backgroud_divider_button.dart';
 import 'package:farmus/common/theme/farmus_theme_color.dart';
 import 'package:farmus/common/theme/farmus_theme_text_style.dart';
+import 'package:farmus/view/farmclub/farmclub_screen.dart';
 import 'package:farmus/view/farmclub_sign_up/component/farmclub_%20preparations.dart';
 import 'package:farmus/view/farmclub_sign_up/component/farmclub_more_info_widget.dart';
 import 'package:farmus/view/farmclub_sign_up/component/farmclub_only_container.dart';
@@ -104,7 +105,8 @@ class FarmclubSignUpScreen extends ConsumerWidget {
                 button: FarmclubSignUpButton(
                   id: farmclubDetailModel.farmClubId,
                   myVeggieInfoId: farmclubDetailModel.veggieInfoId,
-                  onPressed: () {},
+                  onPressed: () {
+                  },
                 ),
               ),
             ],

--- a/lib/view/farmclub_sign_up/farmclub_sign_up_screen.dart
+++ b/lib/view/farmclub_sign_up/farmclub_sign_up_screen.dart
@@ -115,7 +115,7 @@ class FarmclubSignUpScreen extends ConsumerWidget {
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stack) =>
-          Center(child: Text('Failed to load : $error')),
+          Center(child: Text('Failed to load data: $error')),
     );
   }
 }


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #206


### 🍠 Summary
팜클럽 가입하기 버튼 누른 후, 해당 팜클럽으로 화면이동
그 후 다시 탐색 탭 오면 팜클럽 인원 수 데이터 최신화

https://github.com/Mojacknong/Farmus_App/assets/105162858/a681d2bd-db03-4b1f-b94e-5afbd6343436


### 🌽 PR Type
- [ ] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
vscode에서 안드로이드 스튜디오로 변경하면서 가벼운 문제로 커밋했는데 푸시하기 전 커밋 파일들이 푸시 리스트에서 사라져서 마지막 2개 커밋은 의미 없는 커밋들입니다...!

피그마 다시 읽어보니 가입하기 버튼 누르면 바로 해당 팜클럽으로 이동해야한다고 적혀있었네요 ㅎㅎ..
수정할 점 있으면 편하게 말씀해주세요!! 