### PR TITLE
[Feat] 팜클럽 미션 조회 API 연동

### DIFF
--- a/lib/common/app_bar/home_app_bar.dart
+++ b/lib/common/app_bar/home_app_bar.dart
@@ -31,7 +31,7 @@ class HomeScreenAppBar extends StatelessWidget implements PreferredSizeWidget {
       actions: [
         IconButton(
           onPressed: () {},
-          icon: SvgPicture.asset("assets/image/ic_bell.svg"),
+          icon: SvgPicture.asset('assets/image/ic_bell.svg'),
         )
       ],
     );

--- a/lib/common/button/home_my_vege_button.dart
+++ b/lib/common/button/home_my_vege_button.dart
@@ -5,13 +5,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../theme/farmus_theme_color.dart';
 
 class HomeMyVegeButton extends ConsumerWidget {
-  const HomeMyVegeButton({
-    super.key,
-    required this.enabled,
-    required this.text,
-    required this.onPressed,
-    required this.fontPadding,
-  });
+  const HomeMyVegeButton(
+      {super.key,
+      required this.enabled,
+      required this.text,
+      required this.onPressed,
+      required this.fontPadding,
+      required this.padding});
 
   final bool enabled;
 
@@ -20,6 +20,7 @@ class HomeMyVegeButton extends ConsumerWidget {
   final String text;
 
   final double fontPadding;
+  final double padding;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -34,6 +35,7 @@ class HomeMyVegeButton extends ConsumerWidget {
       borderRadius: 25.0,
       onPressed: onPressed,
       fontPadding: fontPadding,
+      padding: EdgeInsets.symmetric(horizontal: padding),
     );
   }
 }

--- a/lib/common/tab_bar/farmclub_tab_bar.dart
+++ b/lib/common/tab_bar/farmclub_tab_bar.dart
@@ -8,15 +8,14 @@ import 'package:flutter/material.dart';
 class FarmclubTabBar extends StatelessWidget {
   final MyFarmclubInfoModel farmclubInfo;
 
-  const FarmclubTabBar({Key? key, required this.farmclubInfo})
-      : super(key: key);
+  const FarmclubTabBar({super.key, required this.farmclubInfo});
 
   @override
   Widget build(BuildContext context) {
     final List<StepModel> steps = farmclubInfo.steps;
 
     int currentStepIndex = (farmclubInfo.daysSinceStart >= 0 &&
-        farmclubInfo.daysSinceStart < steps.length)
+            farmclubInfo.daysSinceStart < steps.length)
         ? farmclubInfo.daysSinceStart
         : 0;
 
@@ -25,7 +24,7 @@ class FarmclubTabBar extends StatelessWidget {
         : [steps[currentStepIndex]];
 
     final List<StepModel> previousSteps =
-    (currentStepIndex > 0) ? steps.sublist(0, currentStepIndex) : [];
+        (currentStepIndex > 0) ? steps.sublist(0, currentStepIndex) : [];
     final List<StepModel> nextSteps = (currentStepIndex < steps.length - 1)
         ? steps.sublist(currentStepIndex + 1)
         : [];
@@ -42,9 +41,10 @@ class FarmclubTabBar extends StatelessWidget {
                   child: FarmclubStep(
                     wholeMember: farmclubInfo.wholeMemberCount,
                     step: step,
+                    farmclubInfo: farmclubInfo,
                   ),
                 );
-              }).toList(),
+              }),
               if (addTip)
                 FarmclubStepTip(
                   tip: farmclubInfo.advice,

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -10,21 +10,43 @@ class MyFarmclubService {
 
   Future<String> myFarmclub() async {
     const url = '/api/farm-club/me';
-    return _fetchData(url, '내 팜클럽 불러오기 실패');
+    return _fetchData('get', url, '내 팜클럽 불러오기 실패');
   }
 
   Future<String> myFarmclubInfo(int farmclubId) async {
     final url = '/api/farm-club/me/$farmclubId';
-    return _fetchData(url, '내 팜클럽 정보 불러오기 실패');
+    return _fetchData('get', url, '내 팜클럽 정보 불러오기 실패');
   }
 
   Future<String> farmclubHelp(int farmclubId) async {
     final url = '/api/farm-club/$farmclubId/help';
-    return _fetchData(url, '내 팜클럽 도움말 불러오기 실패');
+    return _fetchData('get', url, '내 팜클럽 도움말 불러오기 실패');
   }
 
-  Future<String> _fetchData(String url, String errorMessage) async {
-    final response = await apiClient.get(url);
+  Future<String> farmclubMissionFeed(int farmclubId) async {
+    final url = '/api/farm-club/$farmclubId/mission';
+    return _fetchData('get', url, '팜클럽 미션 불러오기 실패');
+  }
+
+  Future<String> farmclubMissionCertification() async {
+    const url = '/api/farm-club/mission';
+    return _fetchData('post', url, '팜클럽 미션 인증 실패');
+  }
+
+  Future<String> _fetchData(
+      String method, String url, String errorMessage) async {
+    final response;
+
+    switch (method) {
+      case 'get':
+        response = await apiClient.get(url);
+        break;
+      case 'post':
+        response = await apiClient.post(url);
+        break;
+      default:
+        throw Exception('Unsupported HTTP method: $method');
+    }
 
     if (response.statusCode == 200) {
       return utf8.decode(response.bodyBytes);

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 
+import '../../model/mission/mission_write_model.dart';
 import 'base_api_services.dart';
 
 class MyFarmclubService {
@@ -10,43 +12,48 @@ class MyFarmclubService {
 
   Future<String> myFarmclub() async {
     const url = '/api/farm-club/me';
-    return _fetchData('get', url, '내 팜클럽 불러오기 실패');
+    return _fetchData(url, '내 팜클럽 불러오기 실패');
   }
 
   Future<String> myFarmclubInfo(int farmclubId) async {
     final url = '/api/farm-club/me/$farmclubId';
-    return _fetchData('get', url, '내 팜클럽 정보 불러오기 실패');
+    return _fetchData(url, '내 팜클럽 정보 불러오기 실패');
   }
 
   Future<String> farmclubHelp(int farmclubId) async {
     final url = '/api/farm-club/$farmclubId/help';
-    return _fetchData('get', url, '내 팜클럽 도움말 불러오기 실패');
+    return _fetchData(url, '내 팜클럽 도움말 불러오기 실패');
   }
 
   Future<String> farmclubMissionFeed(int farmclubId) async {
     final url = '/api/farm-club/$farmclubId/mission';
-    return _fetchData('get', url, '팜클럽 미션 불러오기 실패');
+    return _fetchData(url, '팜클럽 미션 불러오기 실패');
   }
 
-  Future<String> farmclubMissionCertification() async {
+  Future<String> farmclubMissionCertification(
+      MissionWriteModel mission, int farmclubId, int stepNum) async {
     const url = '/api/farm-club/mission';
-    return _fetchData('post', url, '팜클럽 미션 인증 실패');
+    ApiClient apiClient = ApiClient();
+    Map<String, String> headers = {
+      HttpHeaders.contentTypeHeader: 'application/json',
+    };
+
+    final body = jsonEncode({
+      'userFarmClubId': farmclubId,
+      'content': mission.content,
+      'stepNum': stepNum
+    });
+    final response = await apiClient.post(url, headers: headers, body: body);
+
+    if (response.statusCode == 200) {
+      return utf8.decode(response.bodyBytes);
+    } else {
+      throw Exception('미션 인증 실패');
+    }
   }
 
-  Future<String> _fetchData(
-      String method, String url, String errorMessage) async {
-    final response;
-
-    switch (method) {
-      case 'get':
-        response = await apiClient.get(url);
-        break;
-      case 'post':
-        response = await apiClient.post(url);
-        break;
-      default:
-        throw Exception('Unsupported HTTP method: $method');
-    }
+  Future<String> _fetchData(String url, String errorMessage) async {
+    final response = await apiClient.get(url);
 
     if (response.statusCode == 200) {
       return utf8.decode(response.bodyBytes);

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -1,33 +1,34 @@
 import 'dart:convert';
-
 import 'base_api_services.dart';
 
 class MyFarmclubService {
+  final ApiClient apiClient;
+
+  MyFarmclubService({ApiClient? apiClient})
+      : apiClient = apiClient ?? ApiClient();
+
   Future<String> myFarmclub() async {
     const url = '/api/farm-club/me';
-
-    ApiClient apiClient = ApiClient();
-
-    final response = await apiClient.get(url);
-
-    if (response.statusCode == 200) {
-      return utf8.decode(response.bodyBytes);
-    } else {
-      throw Exception('Failed to My Farmclub List');
-    }
+    return _fetchData(url, 'Failed to My Farmclub List');
   }
 
   Future<String> myFarmclubInfo(int farmclubId) async {
     final url = '/api/farm-club/me/$farmclubId';
+    return _fetchData(url, 'Failed to My Veggie List');
+  }
 
-    ApiClient apiClient = ApiClient();
+  Future<String> farmclubHelp(int farmclubId) async {
+    final url = '/api/farm-club/$farmclubId/help';
+    return _fetchData(url, 'Failed to get Farmclub Help');
+  }
 
+  Future<String> _fetchData(String url, String errorMessage) async {
     final response = await apiClient.get(url);
 
     if (response.statusCode == 200) {
       return utf8.decode(response.bodyBytes);
     } else {
-      throw Exception('Failed to My Veggie List');
+      throw Exception(errorMessage);
     }
   }
 }

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'base_api_services.dart';
 
 class MyFarmclubService {
@@ -9,17 +10,17 @@ class MyFarmclubService {
 
   Future<String> myFarmclub() async {
     const url = '/api/farm-club/me';
-    return _fetchData(url, 'Failed to My Farmclub List');
+    return _fetchData(url, '내 팜클럽 불러오기 실패');
   }
 
   Future<String> myFarmclubInfo(int farmclubId) async {
     final url = '/api/farm-club/me/$farmclubId';
-    return _fetchData(url, 'Failed to My Veggie List');
+    return _fetchData(url, '내 팜클럽 정보 불러오기 실패');
   }
 
   Future<String> farmclubHelp(int farmclubId) async {
     final url = '/api/farm-club/$farmclubId/help';
-    return _fetchData(url, 'Failed to get Farmclub Help');
+    return _fetchData(url, '내 팜클럽 도움말 불러오기 실패');
   }
 
   Future<String> _fetchData(String url, String errorMessage) async {

--- a/lib/model/my_farmclub/farmclub_help_model.dart
+++ b/lib/model/my_farmclub/farmclub_help_model.dart
@@ -1,4 +1,5 @@
 
+import 'package:farmus/model/search/farmclub_help_info_model.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'farmclub_help_model.freezed.dart';
@@ -7,23 +8,13 @@ part 'farmclub_help_model.g.dart';
 @freezed
 class FarmclubHelpModel with _$FarmclubHelpModel {
   const factory FarmclubHelpModel({
-    required Help help,
+    required FarmclubHelpInfoModel farmclubHelpInfoModel,
     required List<HelpStep> steps,
   }) = _FarmclubHelpModel;
 
   factory FarmclubHelpModel.fromJson(Map<String, dynamic> json) => _$FarmclubHelpModelFromJson(json);
 }
 
-@freezed
-class Help with _$Help {
-  const factory Help({
-    required String material,
-    required List<String> selectHow,
-    required List<String> features,
-  }) = _Help;
-
-  factory Help.fromJson(Map<String, dynamic> json) => _$HelpFromJson(json);
-}
 
 @freezed
 class HelpStep with _$HelpStep {

--- a/lib/model/my_farmclub/farmclub_help_model.dart
+++ b/lib/model/my_farmclub/farmclub_help_model.dart
@@ -1,0 +1,37 @@
+
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'farmclub_help_model.freezed.dart';
+part 'farmclub_help_model.g.dart';
+
+@freezed
+class FarmclubHelpModel with _$FarmclubHelpModel {
+  const factory FarmclubHelpModel({
+    required Help help,
+    required List<HelpStep> steps,
+  }) = _FarmclubHelpModel;
+
+  factory FarmclubHelpModel.fromJson(Map<String, dynamic> json) => _$FarmclubHelpModelFromJson(json);
+}
+
+@freezed
+class Help with _$Help {
+  const factory Help({
+    required String material,
+    required List<String> selectHow,
+    required List<String> features,
+  }) = _Help;
+
+  factory Help.fromJson(Map<String, dynamic> json) => _$HelpFromJson(json);
+}
+
+@freezed
+class HelpStep with _$HelpStep {
+  const factory HelpStep({
+    required int num,
+    required String content,
+    required List<String> tips,
+  }) = _HelpStep;
+
+  factory HelpStep.fromJson(Map<String, dynamic> json) => _$HelpStepFromJson(json);
+}

--- a/lib/model/my_farmclub/farmclub_help_model.freezed.dart
+++ b/lib/model/my_farmclub/farmclub_help_model.freezed.dart
@@ -1,0 +1,559 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'farmclub_help_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+FarmclubHelpModel _$FarmclubHelpModelFromJson(Map<String, dynamic> json) {
+  return _FarmclubHelpModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$FarmclubHelpModel {
+  Help get help => throw _privateConstructorUsedError;
+  List<HelpStep> get steps => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $FarmclubHelpModelCopyWith<FarmclubHelpModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $FarmclubHelpModelCopyWith<$Res> {
+  factory $FarmclubHelpModelCopyWith(
+          FarmclubHelpModel value, $Res Function(FarmclubHelpModel) then) =
+      _$FarmclubHelpModelCopyWithImpl<$Res, FarmclubHelpModel>;
+  @useResult
+  $Res call({Help help, List<HelpStep> steps});
+
+  $HelpCopyWith<$Res> get help;
+}
+
+/// @nodoc
+class _$FarmclubHelpModelCopyWithImpl<$Res, $Val extends FarmclubHelpModel>
+    implements $FarmclubHelpModelCopyWith<$Res> {
+  _$FarmclubHelpModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? help = null,
+    Object? steps = null,
+  }) {
+    return _then(_value.copyWith(
+      help: null == help
+          ? _value.help
+          : help // ignore: cast_nullable_to_non_nullable
+              as Help,
+      steps: null == steps
+          ? _value.steps
+          : steps // ignore: cast_nullable_to_non_nullable
+              as List<HelpStep>,
+    ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $HelpCopyWith<$Res> get help {
+    return $HelpCopyWith<$Res>(_value.help, (value) {
+      return _then(_value.copyWith(help: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$FarmclubHelpModelImplCopyWith<$Res>
+    implements $FarmclubHelpModelCopyWith<$Res> {
+  factory _$$FarmclubHelpModelImplCopyWith(_$FarmclubHelpModelImpl value,
+          $Res Function(_$FarmclubHelpModelImpl) then) =
+      __$$FarmclubHelpModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Help help, List<HelpStep> steps});
+
+  @override
+  $HelpCopyWith<$Res> get help;
+}
+
+/// @nodoc
+class __$$FarmclubHelpModelImplCopyWithImpl<$Res>
+    extends _$FarmclubHelpModelCopyWithImpl<$Res, _$FarmclubHelpModelImpl>
+    implements _$$FarmclubHelpModelImplCopyWith<$Res> {
+  __$$FarmclubHelpModelImplCopyWithImpl(_$FarmclubHelpModelImpl _value,
+      $Res Function(_$FarmclubHelpModelImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? help = null,
+    Object? steps = null,
+  }) {
+    return _then(_$FarmclubHelpModelImpl(
+      help: null == help
+          ? _value.help
+          : help // ignore: cast_nullable_to_non_nullable
+              as Help,
+      steps: null == steps
+          ? _value._steps
+          : steps // ignore: cast_nullable_to_non_nullable
+              as List<HelpStep>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$FarmclubHelpModelImpl implements _FarmclubHelpModel {
+  const _$FarmclubHelpModelImpl(
+      {required this.help, required final List<HelpStep> steps})
+      : _steps = steps;
+
+  factory _$FarmclubHelpModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$FarmclubHelpModelImplFromJson(json);
+
+  @override
+  final Help help;
+  final List<HelpStep> _steps;
+  @override
+  List<HelpStep> get steps {
+    if (_steps is EqualUnmodifiableListView) return _steps;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_steps);
+  }
+
+  @override
+  String toString() {
+    return 'FarmclubHelpModel(help: $help, steps: $steps)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$FarmclubHelpModelImpl &&
+            (identical(other.help, help) || other.help == help) &&
+            const DeepCollectionEquality().equals(other._steps, _steps));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, help, const DeepCollectionEquality().hash(_steps));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$FarmclubHelpModelImplCopyWith<_$FarmclubHelpModelImpl> get copyWith =>
+      __$$FarmclubHelpModelImplCopyWithImpl<_$FarmclubHelpModelImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$FarmclubHelpModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _FarmclubHelpModel implements FarmclubHelpModel {
+  const factory _FarmclubHelpModel(
+      {required final Help help,
+      required final List<HelpStep> steps}) = _$FarmclubHelpModelImpl;
+
+  factory _FarmclubHelpModel.fromJson(Map<String, dynamic> json) =
+      _$FarmclubHelpModelImpl.fromJson;
+
+  @override
+  Help get help;
+  @override
+  List<HelpStep> get steps;
+  @override
+  @JsonKey(ignore: true)
+  _$$FarmclubHelpModelImplCopyWith<_$FarmclubHelpModelImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+Help _$HelpFromJson(Map<String, dynamic> json) {
+  return _Help.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Help {
+  String get material => throw _privateConstructorUsedError;
+  List<String> get selectHow => throw _privateConstructorUsedError;
+  List<String> get features => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $HelpCopyWith<Help> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HelpCopyWith<$Res> {
+  factory $HelpCopyWith(Help value, $Res Function(Help) then) =
+      _$HelpCopyWithImpl<$Res, Help>;
+  @useResult
+  $Res call({String material, List<String> selectHow, List<String> features});
+}
+
+/// @nodoc
+class _$HelpCopyWithImpl<$Res, $Val extends Help>
+    implements $HelpCopyWith<$Res> {
+  _$HelpCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? material = null,
+    Object? selectHow = null,
+    Object? features = null,
+  }) {
+    return _then(_value.copyWith(
+      material: null == material
+          ? _value.material
+          : material // ignore: cast_nullable_to_non_nullable
+              as String,
+      selectHow: null == selectHow
+          ? _value.selectHow
+          : selectHow // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      features: null == features
+          ? _value.features
+          : features // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$HelpImplCopyWith<$Res> implements $HelpCopyWith<$Res> {
+  factory _$$HelpImplCopyWith(
+          _$HelpImpl value, $Res Function(_$HelpImpl) then) =
+      __$$HelpImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String material, List<String> selectHow, List<String> features});
+}
+
+/// @nodoc
+class __$$HelpImplCopyWithImpl<$Res>
+    extends _$HelpCopyWithImpl<$Res, _$HelpImpl>
+    implements _$$HelpImplCopyWith<$Res> {
+  __$$HelpImplCopyWithImpl(_$HelpImpl _value, $Res Function(_$HelpImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? material = null,
+    Object? selectHow = null,
+    Object? features = null,
+  }) {
+    return _then(_$HelpImpl(
+      material: null == material
+          ? _value.material
+          : material // ignore: cast_nullable_to_non_nullable
+              as String,
+      selectHow: null == selectHow
+          ? _value._selectHow
+          : selectHow // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+      features: null == features
+          ? _value._features
+          : features // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$HelpImpl implements _Help {
+  const _$HelpImpl(
+      {required this.material,
+      required final List<String> selectHow,
+      required final List<String> features})
+      : _selectHow = selectHow,
+        _features = features;
+
+  factory _$HelpImpl.fromJson(Map<String, dynamic> json) =>
+      _$$HelpImplFromJson(json);
+
+  @override
+  final String material;
+  final List<String> _selectHow;
+  @override
+  List<String> get selectHow {
+    if (_selectHow is EqualUnmodifiableListView) return _selectHow;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_selectHow);
+  }
+
+  final List<String> _features;
+  @override
+  List<String> get features {
+    if (_features is EqualUnmodifiableListView) return _features;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_features);
+  }
+
+  @override
+  String toString() {
+    return 'Help(material: $material, selectHow: $selectHow, features: $features)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HelpImpl &&
+            (identical(other.material, material) ||
+                other.material == material) &&
+            const DeepCollectionEquality()
+                .equals(other._selectHow, _selectHow) &&
+            const DeepCollectionEquality().equals(other._features, _features));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      material,
+      const DeepCollectionEquality().hash(_selectHow),
+      const DeepCollectionEquality().hash(_features));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HelpImplCopyWith<_$HelpImpl> get copyWith =>
+      __$$HelpImplCopyWithImpl<_$HelpImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$HelpImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Help implements Help {
+  const factory _Help(
+      {required final String material,
+      required final List<String> selectHow,
+      required final List<String> features}) = _$HelpImpl;
+
+  factory _Help.fromJson(Map<String, dynamic> json) = _$HelpImpl.fromJson;
+
+  @override
+  String get material;
+  @override
+  List<String> get selectHow;
+  @override
+  List<String> get features;
+  @override
+  @JsonKey(ignore: true)
+  _$$HelpImplCopyWith<_$HelpImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+HelpStep _$HelpStepFromJson(Map<String, dynamic> json) {
+  return _HelpStep.fromJson(json);
+}
+
+/// @nodoc
+mixin _$HelpStep {
+  int get num => throw _privateConstructorUsedError;
+  String get content => throw _privateConstructorUsedError;
+  List<String> get tips => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $HelpStepCopyWith<HelpStep> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $HelpStepCopyWith<$Res> {
+  factory $HelpStepCopyWith(HelpStep value, $Res Function(HelpStep) then) =
+      _$HelpStepCopyWithImpl<$Res, HelpStep>;
+  @useResult
+  $Res call({int num, String content, List<String> tips});
+}
+
+/// @nodoc
+class _$HelpStepCopyWithImpl<$Res, $Val extends HelpStep>
+    implements $HelpStepCopyWith<$Res> {
+  _$HelpStepCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? num = null,
+    Object? content = null,
+    Object? tips = null,
+  }) {
+    return _then(_value.copyWith(
+      num: null == num
+          ? _value.num
+          : num // ignore: cast_nullable_to_non_nullable
+              as int,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      tips: null == tips
+          ? _value.tips
+          : tips // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$HelpStepImplCopyWith<$Res>
+    implements $HelpStepCopyWith<$Res> {
+  factory _$$HelpStepImplCopyWith(
+          _$HelpStepImpl value, $Res Function(_$HelpStepImpl) then) =
+      __$$HelpStepImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int num, String content, List<String> tips});
+}
+
+/// @nodoc
+class __$$HelpStepImplCopyWithImpl<$Res>
+    extends _$HelpStepCopyWithImpl<$Res, _$HelpStepImpl>
+    implements _$$HelpStepImplCopyWith<$Res> {
+  __$$HelpStepImplCopyWithImpl(
+      _$HelpStepImpl _value, $Res Function(_$HelpStepImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? num = null,
+    Object? content = null,
+    Object? tips = null,
+  }) {
+    return _then(_$HelpStepImpl(
+      num: null == num
+          ? _value.num
+          : num // ignore: cast_nullable_to_non_nullable
+              as int,
+      content: null == content
+          ? _value.content
+          : content // ignore: cast_nullable_to_non_nullable
+              as String,
+      tips: null == tips
+          ? _value._tips
+          : tips // ignore: cast_nullable_to_non_nullable
+              as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$HelpStepImpl implements _HelpStep {
+  const _$HelpStepImpl(
+      {required this.num,
+      required this.content,
+      required final List<String> tips})
+      : _tips = tips;
+
+  factory _$HelpStepImpl.fromJson(Map<String, dynamic> json) =>
+      _$$HelpStepImplFromJson(json);
+
+  @override
+  final int num;
+  @override
+  final String content;
+  final List<String> _tips;
+  @override
+  List<String> get tips {
+    if (_tips is EqualUnmodifiableListView) return _tips;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_tips);
+  }
+
+  @override
+  String toString() {
+    return 'HelpStep(num: $num, content: $content, tips: $tips)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$HelpStepImpl &&
+            (identical(other.num, num) || other.num == num) &&
+            (identical(other.content, content) || other.content == content) &&
+            const DeepCollectionEquality().equals(other._tips, _tips));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, num, content, const DeepCollectionEquality().hash(_tips));
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$HelpStepImplCopyWith<_$HelpStepImpl> get copyWith =>
+      __$$HelpStepImplCopyWithImpl<_$HelpStepImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$HelpStepImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _HelpStep implements HelpStep {
+  const factory _HelpStep(
+      {required final int num,
+      required final String content,
+      required final List<String> tips}) = _$HelpStepImpl;
+
+  factory _HelpStep.fromJson(Map<String, dynamic> json) =
+      _$HelpStepImpl.fromJson;
+
+  @override
+  int get num;
+  @override
+  String get content;
+  @override
+  List<String> get tips;
+  @override
+  @JsonKey(ignore: true)
+  _$$HelpStepImplCopyWith<_$HelpStepImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/my_farmclub/farmclub_help_model.freezed.dart
+++ b/lib/model/my_farmclub/farmclub_help_model.freezed.dart
@@ -20,7 +20,8 @@ FarmclubHelpModel _$FarmclubHelpModelFromJson(Map<String, dynamic> json) {
 
 /// @nodoc
 mixin _$FarmclubHelpModel {
-  Help get help => throw _privateConstructorUsedError;
+  FarmclubHelpInfoModel get farmclubHelpInfoModel =>
+      throw _privateConstructorUsedError;
   List<HelpStep> get steps => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -35,9 +36,10 @@ abstract class $FarmclubHelpModelCopyWith<$Res> {
           FarmclubHelpModel value, $Res Function(FarmclubHelpModel) then) =
       _$FarmclubHelpModelCopyWithImpl<$Res, FarmclubHelpModel>;
   @useResult
-  $Res call({Help help, List<HelpStep> steps});
+  $Res call(
+      {FarmclubHelpInfoModel farmclubHelpInfoModel, List<HelpStep> steps});
 
-  $HelpCopyWith<$Res> get help;
+  $FarmclubHelpInfoModelCopyWith<$Res> get farmclubHelpInfoModel;
 }
 
 /// @nodoc
@@ -53,14 +55,14 @@ class _$FarmclubHelpModelCopyWithImpl<$Res, $Val extends FarmclubHelpModel>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? help = null,
+    Object? farmclubHelpInfoModel = null,
     Object? steps = null,
   }) {
     return _then(_value.copyWith(
-      help: null == help
-          ? _value.help
-          : help // ignore: cast_nullable_to_non_nullable
-              as Help,
+      farmclubHelpInfoModel: null == farmclubHelpInfoModel
+          ? _value.farmclubHelpInfoModel
+          : farmclubHelpInfoModel // ignore: cast_nullable_to_non_nullable
+              as FarmclubHelpInfoModel,
       steps: null == steps
           ? _value.steps
           : steps // ignore: cast_nullable_to_non_nullable
@@ -70,9 +72,10 @@ class _$FarmclubHelpModelCopyWithImpl<$Res, $Val extends FarmclubHelpModel>
 
   @override
   @pragma('vm:prefer-inline')
-  $HelpCopyWith<$Res> get help {
-    return $HelpCopyWith<$Res>(_value.help, (value) {
-      return _then(_value.copyWith(help: value) as $Val);
+  $FarmclubHelpInfoModelCopyWith<$Res> get farmclubHelpInfoModel {
+    return $FarmclubHelpInfoModelCopyWith<$Res>(_value.farmclubHelpInfoModel,
+        (value) {
+      return _then(_value.copyWith(farmclubHelpInfoModel: value) as $Val);
     });
   }
 }
@@ -85,10 +88,11 @@ abstract class _$$FarmclubHelpModelImplCopyWith<$Res>
       __$$FarmclubHelpModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({Help help, List<HelpStep> steps});
+  $Res call(
+      {FarmclubHelpInfoModel farmclubHelpInfoModel, List<HelpStep> steps});
 
   @override
-  $HelpCopyWith<$Res> get help;
+  $FarmclubHelpInfoModelCopyWith<$Res> get farmclubHelpInfoModel;
 }
 
 /// @nodoc
@@ -102,14 +106,14 @@ class __$$FarmclubHelpModelImplCopyWithImpl<$Res>
   @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? help = null,
+    Object? farmclubHelpInfoModel = null,
     Object? steps = null,
   }) {
     return _then(_$FarmclubHelpModelImpl(
-      help: null == help
-          ? _value.help
-          : help // ignore: cast_nullable_to_non_nullable
-              as Help,
+      farmclubHelpInfoModel: null == farmclubHelpInfoModel
+          ? _value.farmclubHelpInfoModel
+          : farmclubHelpInfoModel // ignore: cast_nullable_to_non_nullable
+              as FarmclubHelpInfoModel,
       steps: null == steps
           ? _value._steps
           : steps // ignore: cast_nullable_to_non_nullable
@@ -122,14 +126,15 @@ class __$$FarmclubHelpModelImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$FarmclubHelpModelImpl implements _FarmclubHelpModel {
   const _$FarmclubHelpModelImpl(
-      {required this.help, required final List<HelpStep> steps})
+      {required this.farmclubHelpInfoModel,
+      required final List<HelpStep> steps})
       : _steps = steps;
 
   factory _$FarmclubHelpModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$FarmclubHelpModelImplFromJson(json);
 
   @override
-  final Help help;
+  final FarmclubHelpInfoModel farmclubHelpInfoModel;
   final List<HelpStep> _steps;
   @override
   List<HelpStep> get steps {
@@ -140,7 +145,7 @@ class _$FarmclubHelpModelImpl implements _FarmclubHelpModel {
 
   @override
   String toString() {
-    return 'FarmclubHelpModel(help: $help, steps: $steps)';
+    return 'FarmclubHelpModel(farmclubHelpInfoModel: $farmclubHelpInfoModel, steps: $steps)';
   }
 
   @override
@@ -148,14 +153,15 @@ class _$FarmclubHelpModelImpl implements _FarmclubHelpModel {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$FarmclubHelpModelImpl &&
-            (identical(other.help, help) || other.help == help) &&
+            (identical(other.farmclubHelpInfoModel, farmclubHelpInfoModel) ||
+                other.farmclubHelpInfoModel == farmclubHelpInfoModel) &&
             const DeepCollectionEquality().equals(other._steps, _steps));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, help, const DeepCollectionEquality().hash(_steps));
+  int get hashCode => Object.hash(runtimeType, farmclubHelpInfoModel,
+      const DeepCollectionEquality().hash(_steps));
 
   @JsonKey(ignore: true)
   @override
@@ -174,207 +180,19 @@ class _$FarmclubHelpModelImpl implements _FarmclubHelpModel {
 
 abstract class _FarmclubHelpModel implements FarmclubHelpModel {
   const factory _FarmclubHelpModel(
-      {required final Help help,
+      {required final FarmclubHelpInfoModel farmclubHelpInfoModel,
       required final List<HelpStep> steps}) = _$FarmclubHelpModelImpl;
 
   factory _FarmclubHelpModel.fromJson(Map<String, dynamic> json) =
       _$FarmclubHelpModelImpl.fromJson;
 
   @override
-  Help get help;
+  FarmclubHelpInfoModel get farmclubHelpInfoModel;
   @override
   List<HelpStep> get steps;
   @override
   @JsonKey(ignore: true)
   _$$FarmclubHelpModelImplCopyWith<_$FarmclubHelpModelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-Help _$HelpFromJson(Map<String, dynamic> json) {
-  return _Help.fromJson(json);
-}
-
-/// @nodoc
-mixin _$Help {
-  String get material => throw _privateConstructorUsedError;
-  List<String> get selectHow => throw _privateConstructorUsedError;
-  List<String> get features => throw _privateConstructorUsedError;
-
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $HelpCopyWith<Help> get copyWith => throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $HelpCopyWith<$Res> {
-  factory $HelpCopyWith(Help value, $Res Function(Help) then) =
-      _$HelpCopyWithImpl<$Res, Help>;
-  @useResult
-  $Res call({String material, List<String> selectHow, List<String> features});
-}
-
-/// @nodoc
-class _$HelpCopyWithImpl<$Res, $Val extends Help>
-    implements $HelpCopyWith<$Res> {
-  _$HelpCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? material = null,
-    Object? selectHow = null,
-    Object? features = null,
-  }) {
-    return _then(_value.copyWith(
-      material: null == material
-          ? _value.material
-          : material // ignore: cast_nullable_to_non_nullable
-              as String,
-      selectHow: null == selectHow
-          ? _value.selectHow
-          : selectHow // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      features: null == features
-          ? _value.features
-          : features // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$HelpImplCopyWith<$Res> implements $HelpCopyWith<$Res> {
-  factory _$$HelpImplCopyWith(
-          _$HelpImpl value, $Res Function(_$HelpImpl) then) =
-      __$$HelpImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String material, List<String> selectHow, List<String> features});
-}
-
-/// @nodoc
-class __$$HelpImplCopyWithImpl<$Res>
-    extends _$HelpCopyWithImpl<$Res, _$HelpImpl>
-    implements _$$HelpImplCopyWith<$Res> {
-  __$$HelpImplCopyWithImpl(_$HelpImpl _value, $Res Function(_$HelpImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? material = null,
-    Object? selectHow = null,
-    Object? features = null,
-  }) {
-    return _then(_$HelpImpl(
-      material: null == material
-          ? _value.material
-          : material // ignore: cast_nullable_to_non_nullable
-              as String,
-      selectHow: null == selectHow
-          ? _value._selectHow
-          : selectHow // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-      features: null == features
-          ? _value._features
-          : features // ignore: cast_nullable_to_non_nullable
-              as List<String>,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$HelpImpl implements _Help {
-  const _$HelpImpl(
-      {required this.material,
-      required final List<String> selectHow,
-      required final List<String> features})
-      : _selectHow = selectHow,
-        _features = features;
-
-  factory _$HelpImpl.fromJson(Map<String, dynamic> json) =>
-      _$$HelpImplFromJson(json);
-
-  @override
-  final String material;
-  final List<String> _selectHow;
-  @override
-  List<String> get selectHow {
-    if (_selectHow is EqualUnmodifiableListView) return _selectHow;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_selectHow);
-  }
-
-  final List<String> _features;
-  @override
-  List<String> get features {
-    if (_features is EqualUnmodifiableListView) return _features;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_features);
-  }
-
-  @override
-  String toString() {
-    return 'Help(material: $material, selectHow: $selectHow, features: $features)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$HelpImpl &&
-            (identical(other.material, material) ||
-                other.material == material) &&
-            const DeepCollectionEquality()
-                .equals(other._selectHow, _selectHow) &&
-            const DeepCollectionEquality().equals(other._features, _features));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      material,
-      const DeepCollectionEquality().hash(_selectHow),
-      const DeepCollectionEquality().hash(_features));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$HelpImplCopyWith<_$HelpImpl> get copyWith =>
-      __$$HelpImplCopyWithImpl<_$HelpImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$HelpImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _Help implements Help {
-  const factory _Help(
-      {required final String material,
-      required final List<String> selectHow,
-      required final List<String> features}) = _$HelpImpl;
-
-  factory _Help.fromJson(Map<String, dynamic> json) = _$HelpImpl.fromJson;
-
-  @override
-  String get material;
-  @override
-  List<String> get selectHow;
-  @override
-  List<String> get features;
-  @override
-  @JsonKey(ignore: true)
-  _$$HelpImplCopyWith<_$HelpImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }
 

--- a/lib/model/my_farmclub/farmclub_help_model.g.dart
+++ b/lib/model/my_farmclub/farmclub_help_model.g.dart
@@ -9,7 +9,8 @@ part of 'farmclub_help_model.dart';
 _$FarmclubHelpModelImpl _$$FarmclubHelpModelImplFromJson(
         Map<String, dynamic> json) =>
     _$FarmclubHelpModelImpl(
-      help: Help.fromJson(json['help'] as Map<String, dynamic>),
+      farmclubHelpInfoModel: FarmclubHelpInfoModel.fromJson(
+          json['farmclubHelpInfoModel'] as Map<String, dynamic>),
       steps: (json['steps'] as List<dynamic>)
           .map((e) => HelpStep.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -18,23 +19,8 @@ _$FarmclubHelpModelImpl _$$FarmclubHelpModelImplFromJson(
 Map<String, dynamic> _$$FarmclubHelpModelImplToJson(
         _$FarmclubHelpModelImpl instance) =>
     <String, dynamic>{
-      'help': instance.help,
+      'farmclubHelpInfoModel': instance.farmclubHelpInfoModel,
       'steps': instance.steps,
-    };
-
-_$HelpImpl _$$HelpImplFromJson(Map<String, dynamic> json) => _$HelpImpl(
-      material: json['material'] as String,
-      selectHow:
-          (json['selectHow'] as List<dynamic>).map((e) => e as String).toList(),
-      features:
-          (json['features'] as List<dynamic>).map((e) => e as String).toList(),
-    );
-
-Map<String, dynamic> _$$HelpImplToJson(_$HelpImpl instance) =>
-    <String, dynamic>{
-      'material': instance.material,
-      'selectHow': instance.selectHow,
-      'features': instance.features,
     };
 
 _$HelpStepImpl _$$HelpStepImplFromJson(Map<String, dynamic> json) =>

--- a/lib/model/my_farmclub/farmclub_help_model.g.dart
+++ b/lib/model/my_farmclub/farmclub_help_model.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'farmclub_help_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$FarmclubHelpModelImpl _$$FarmclubHelpModelImplFromJson(
+        Map<String, dynamic> json) =>
+    _$FarmclubHelpModelImpl(
+      help: Help.fromJson(json['help'] as Map<String, dynamic>),
+      steps: (json['steps'] as List<dynamic>)
+          .map((e) => HelpStep.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$FarmclubHelpModelImplToJson(
+        _$FarmclubHelpModelImpl instance) =>
+    <String, dynamic>{
+      'help': instance.help,
+      'steps': instance.steps,
+    };
+
+_$HelpImpl _$$HelpImplFromJson(Map<String, dynamic> json) => _$HelpImpl(
+      material: json['material'] as String,
+      selectHow:
+          (json['selectHow'] as List<dynamic>).map((e) => e as String).toList(),
+      features:
+          (json['features'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$$HelpImplToJson(_$HelpImpl instance) =>
+    <String, dynamic>{
+      'material': instance.material,
+      'selectHow': instance.selectHow,
+      'features': instance.features,
+    };
+
+_$HelpStepImpl _$$HelpStepImplFromJson(Map<String, dynamic> json) =>
+    _$HelpStepImpl(
+      num: (json['num'] as num).toInt(),
+      content: json['content'] as String,
+      tips: (json['tips'] as List<dynamic>).map((e) => e as String).toList(),
+    );
+
+Map<String, dynamic> _$$HelpStepImplToJson(_$HelpStepImpl instance) =>
+    <String, dynamic>{
+      'num': instance.num,
+      'content': instance.content,
+      'tips': instance.tips,
+    };

--- a/lib/repository/my_farmclub_repository.dart
+++ b/lib/repository/my_farmclub_repository.dart
@@ -10,4 +10,9 @@ class MyFarmclubRepository {
     String? response = await MyFarmclubService().myFarmclubInfo(farmclubId);
     return response;
   }
+
+  static Future<String> farmclubHelp(int farmclubId) async {
+    String? response = await MyFarmclubService().farmclubHelp(farmclubId);
+    return response;
+  }
 }

--- a/lib/repository/my_farmclub_repository.dart
+++ b/lib/repository/my_farmclub_repository.dart
@@ -15,4 +15,14 @@ class MyFarmclubRepository {
     String? response = await MyFarmclubService().farmclubHelp(farmclubId);
     return response;
   }
+
+  static Future<String> farmclubMission(int farmclubId) async {
+    String? response = await MyFarmclubService().farmclubMissionFeed(farmclubId);
+    return response;
+  }
+
+  static Future<String> farmclubMissionCertification() async {
+    String? response = await MyFarmclubService().farmclubMissionCertification();
+    return response;
+  }
 }

--- a/lib/repository/my_farmclub_repository.dart
+++ b/lib/repository/my_farmclub_repository.dart
@@ -1,5 +1,7 @@
 import 'package:farmus/data/network/my_farmclub_service.dart';
 
+import '../model/mission/mission_write_model.dart';
+
 class MyFarmclubRepository {
   static Future<String> myFarmclub() async {
     String? response = await MyFarmclubService().myFarmclub();
@@ -17,12 +19,15 @@ class MyFarmclubRepository {
   }
 
   static Future<String> farmclubMission(int farmclubId) async {
-    String? response = await MyFarmclubService().farmclubMissionFeed(farmclubId);
+    String? response =
+        await MyFarmclubService().farmclubMissionFeed(farmclubId);
     return response;
   }
 
-  static Future<String> farmclubMissionCertification() async {
-    String? response = await MyFarmclubService().farmclubMissionCertification();
+  static Future<String> farmclubMissionCertification(
+      MissionWriteModel mission, int farmclubId, int stepNum) async {
+    String? response = await MyFarmclubService()
+        .farmclubMissionCertification(mission, farmclubId, stepNum);
     return response;
   }
 }

--- a/lib/view/farmclub/component/farmclub_change_info.dart
+++ b/lib/view/farmclub/component/farmclub_change_info.dart
@@ -28,10 +28,6 @@ class FarmclubChangeInfo extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(vertical: 8.0),
       child: Row(
         children: [
-          FarmclubSelectProfile(image: farmclubImage, size: 56),
-          const SizedBox(
-            width: 16.0,
-          ),
           Expanded(
             child: IntrinsicHeight(
               child: GestureDetector(
@@ -43,6 +39,10 @@ class FarmclubChangeInfo extends ConsumerWidget {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [
+                    FarmclubSelectProfile(image: farmclubImage, size: 56),
+                    const SizedBox(
+                      width: 16.0,
+                    ),
                     Text(
                       farmclubName,
                       style: FarmusThemeTextStyle.darkSemiBold17,

--- a/lib/view/farmclub/component/farmclub_profile.dart
+++ b/lib/view/farmclub/component/farmclub_profile.dart
@@ -12,7 +12,7 @@ import '../../../common/theme/farmus_theme_text_style.dart';
 class FarmclubProfile extends ConsumerWidget {
   final MyFarmclubInfoModel? farmclubInfoModel;
 
-  const FarmclubProfile({Key? key, this.farmclubInfoModel}) : super(key: key);
+  const FarmclubProfile({super.key, this.farmclubInfoModel});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/view/farmclub/component/farmclub_step.dart
+++ b/lib/view/farmclub/component/farmclub_step.dart
@@ -10,16 +10,24 @@ import '../../mission_feed/mission_feed_screen.dart';
 
 class FarmclubStep extends ConsumerWidget {
   const FarmclubStep(
-      {super.key, required this.wholeMember, required this.step});
+      {super.key,
+      required this.wholeMember,
+      required this.step,
+      required this.farmclubInfo});
 
   final int wholeMember;
   final StepModel step;
+  final MyFarmclubInfoModel farmclubInfo;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return GestureDetector(
-      onTap: () => Navigator.push(context,
-          MaterialPageRoute(builder: (builder) => const MissionFeedScreen())),
+      onTap: () => Navigator.push(
+          context,
+          MaterialPageRoute(
+              builder: (builder) => MissionFeedScreen(
+                    farmclubInfo: farmclubInfo,
+                  ))),
       child: Container(
         width: double.infinity,
         decoration: ShapeDecoration(

--- a/lib/view/farmclub/component/farmclub_step.dart
+++ b/lib/view/farmclub/component/farmclub_step.dart
@@ -64,7 +64,8 @@ class FarmclubStep extends ConsumerWidget {
                       ],
                     ),
                   ),
-                  const MissionWriteRouteButton(
+                  MissionWriteRouteButton(
+                    step: step,
                     isButton: true,
                   )
                 ],

--- a/lib/view/farmclub/component/farmclub_step.dart
+++ b/lib/view/farmclub/component/farmclub_step.dart
@@ -1,5 +1,4 @@
 import 'package:farmus/common/farmus_picture_fix.dart';
-import 'package:farmus/view/mission_feed/mission_feed_screen.dart';
 import 'package:farmus/view/mission_write/component/mission_write_route_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../common/theme/farmus_theme_color.dart';
 import '../../../common/theme/farmus_theme_text_style.dart';
 import '../../../model/my_farmclub/my_farmclub_info_model.dart';
+import '../../mission_feed/mission_feed_screen.dart';
 
 class FarmclubStep extends ConsumerWidget {
   const FarmclubStep(
@@ -17,118 +17,115 @@ class FarmclubStep extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Container(
-      width: double.infinity,
-      decoration: ShapeDecoration(
-        color: FarmusThemeColor.background,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(24),
+    return GestureDetector(
+      onTap: () => Navigator.push(context,
+          MaterialPageRoute(builder: (builder) => const MissionFeedScreen())),
+      child: Container(
+        width: double.infinity,
+        decoration: ShapeDecoration(
+          color: FarmusThemeColor.background,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(24),
+          ),
         ),
-      ),
-      margin: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.start,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    crossAxisAlignment: CrossAxisAlignment.start,
+        margin: const EdgeInsets.symmetric(vertical: 8.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          "Step ${step.stepNum + 1}",
+                          style: FarmusThemeTextStyle.gray2SemiBold13,
+                        ),
+                        const SizedBox(
+                          height: 8,
+                        ),
+                        Text(
+                          step.stepName,
+                          style: FarmusThemeTextStyle.darkSemiBold17,
+                        )
+                      ],
+                    ),
+                  ),
+                  const MissionWriteRouteButton(
+                    isButton: true,
+                  )
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 16,
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 16.0, bottom: 16.0),
+              child: Column(
+                children: [
+                  Row(
                     children: [
-                      Text(
-                        "Step ${step.stepNum + 1}",
-                        style: FarmusThemeTextStyle.gray2SemiBold13,
+                      Text.rich(
+                        TextSpan(
+                          style: FarmusThemeTextStyle.gray2SemiBold13,
+                          //apply style to all
+                          children: [
+                            TextSpan(
+                              text: '$wholeMember명 중 ',
+                            ),
+                            TextSpan(
+                                text: '${step.completeMemberCount}명',
+                                style: FarmusThemeTextStyle.redSemiBold13),
+                            const TextSpan(
+                              text: '이 완료했어요',
+                            ),
+                          ],
+                        ),
                       ),
                       const SizedBox(
-                        height: 8,
+                        width: 8,
                       ),
-                      Text(
-                        step.stepName,
-                        style: FarmusThemeTextStyle.darkSemiBold17,
-                      )
+                      Container(
+                        padding: const EdgeInsets.all(4),
+                        decoration: ShapeDecoration(
+                          color: FarmusThemeColor.greenLight3,
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(4)),
+                        ),
+                        child: const Text(
+                          '상추좋아',
+                          style: FarmusThemeTextStyle.green1SemiBold11,
+                        ),
+                      ),
                     ],
                   ),
-                ),
-                const MissionWriteRouteButton(
-                  isButton: true,
-                )
-              ],
-            ),
-          ),
-          const SizedBox(
-            height: 16,
-          ),
-          Padding(
-            padding: const EdgeInsets.only(left: 16.0, bottom: 16.0),
-            child: Column(
-              children: [
-                Row(
-                  children: [
-                    Text.rich(
-                      TextSpan(
-                        style: FarmusThemeTextStyle.gray2SemiBold13,
-                        //apply style to all
-                        children: [
-                          TextSpan(
-                            text: '$wholeMember명 중 ',
-                          ),
-                          TextSpan(
-                              text: '${step.completeMemberCount}명',
-                              style: FarmusThemeTextStyle.redSemiBold13),
-                          const TextSpan(
-                            text: '이 완료했어요',
-                          ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(
-                      width: 8,
-                    ),
-                    Container(
-                      padding: const EdgeInsets.all(4),
-                      decoration: ShapeDecoration(
-                        color: FarmusThemeColor.greenLight3,
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(4)),
-                      ),
-                      child: const Text(
-                        '상추좋아',
-                        style: FarmusThemeTextStyle.green1SemiBold11,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(
-                  height: 8,
-                ),
-                Row(
-                  children: step.images.isNotEmpty
-                      ? step.images.map((image) {
-                          return GestureDetector(
-                            onTap: () => Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (builder) =>
-                                        const MissionFeedScreen())),
-                            child: Padding(
+                  const SizedBox(
+                    height: 8,
+                  ),
+                  Row(
+                    children: step.images.isNotEmpty
+                        ? step.images.map((image) {
+                            return Padding(
                               padding: const EdgeInsets.only(right: 8.0),
                               child: FarmusPictureFix(
                                 size: 82,
                                 image: image,
                               ),
-                            ),
-                          );
-                        }).toList()
-                      : [const SizedBox()],
-                ),
-              ],
+                            );
+                          }).toList()
+                        : [const SizedBox()],
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/view/farmclub/farmclub_screen.dart
+++ b/lib/view/farmclub/farmclub_screen.dart
@@ -17,7 +17,7 @@ import 'component/farmclub_feed.dart';
 import 'component/farmclub_profile.dart';
 
 class FarmclubScreen extends ConsumerWidget {
-  const FarmclubScreen({Key? key}) : super(key: key);
+  const FarmclubScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/view/home/component/home_my_vege_list.dart
+++ b/lib/view/home/component/home_my_vege_list.dart
@@ -13,7 +13,7 @@ class HomeMyVegeList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selectedVeggieId = ref.watch(selectedVeggieIdProvider);
+    final selectedVegeId = ref.watch(selectedVegeIdProvider);
 
     return FutureBuilder<List<MyVeggieListModel>>(
       future: ref.watch(myVeggieListModelProvider.future),
@@ -48,12 +48,12 @@ class HomeMyVegeList extends ConsumerWidget {
                 (veggie) => Padding(
                   padding: const EdgeInsets.only(right: 6.0),
                   child: HomeMyVegeButton(
-                    enabled: selectedVeggieId == null
+                    enabled: selectedVegeId == null
                         ? veggie.myVeggieId == veggieList.first.myVeggieId
-                        : veggie.myVeggieId == selectedVeggieId,
+                        : veggie.myVeggieId == selectedVegeId,
                     text: veggie.nickname,
                     onPressed: () {
-                      ref.read(selectedVeggieIdProvider.notifier).state =
+                      ref.read(selectedVegeIdProvider.notifier).state =
                           veggie.myVeggieId;
                     },
                     fontPadding: 0,

--- a/lib/view/home/component/home_my_vege_list.dart
+++ b/lib/view/home/component/home_my_vege_list.dart
@@ -56,7 +56,8 @@ class HomeMyVegeList extends ConsumerWidget {
                       ref.read(selectedVeggieIdProvider.notifier).state =
                           veggie.myVeggieId;
                     },
-                    fontPadding: 0.0,
+                    fontPadding: 0,
+                    padding: 16.0,
                   ),
                 ),
               ),

--- a/lib/view/home/home_screen.dart
+++ b/lib/view/home/home_screen.dart
@@ -29,7 +29,7 @@ class HomeScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final Size size = MediaQuery.of(context).size;
-    final selectedVeggieId = ref.watch(selectedVeggieIdProvider);
+    final selectedVegeId = ref.watch(selectedVegeIdProvider);
     final AsyncValue<List<MyVeggieListModel>> veggieList =
         ref.watch(myVeggieListModelProvider);
     final AsyncValue<List<RecommendVeggieModel>> recommend =
@@ -67,10 +67,10 @@ class HomeScreen extends ConsumerWidget {
                   if (veggieListData.isNotEmpty) ...[
                     const HomeMyVegeList(),
                     const SizedBox(height: 8),
-                    if (selectedVeggieId != null)
+                    if (selectedVegeId != null)
                       FutureBuilder<MyVeggieProfile>(
                         future: ref.read(
-                            myVeggieProfileProvider(selectedVeggieId).future),
+                            myVeggieProfileProvider(selectedVegeId).future),
                         builder: (context, snapshot) {
                           if (snapshot.connectionState ==
                               ConnectionState.waiting) {
@@ -127,10 +127,10 @@ class HomeScreen extends ConsumerWidget {
                   const SizedBox(height: 24),
                   const HomeSubTitle(title: "성장 일기"),
                   if (veggieListData.isNotEmpty)
-                    if (selectedVeggieId != null)
+                    if (selectedVegeId != null)
                       FutureBuilder<VeggieDiaryOneModel?>(
                         future: ref.watch(
-                            veggieDiaryOneModelProvider(selectedVeggieId)
+                            veggieDiaryOneModelProvider(selectedVegeId)
                                 .future),
                         builder: (context, snapshot) {
                           if (snapshot.connectionState ==

--- a/lib/view/mission_feed/component/mission_feed_select_profile.dart
+++ b/lib/view/mission_feed/component/mission_feed_select_profile.dart
@@ -1,7 +1,14 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../../common/theme/farmus_theme_text_style.dart';
+import '../../../model/my_farmclub/my_farmclub_info_model.dart';
+import '../../../model/my_farmclub/my_farmclub_model.dart';
+import '../../../view_model/home/home_provider.dart';
+import '../../../view_model/my_farmclub/my_farmclub_info_notifier.dart';
+import '../../../view_model/my_farmclub/my_farmclub_notifier.dart';
+import '../../../view_model/on_boarding/on_boarding_finish_notifier.dart';
 import '../../farmclub/component/farmclub_select_profile.dart';
 
 class MissionFeedSelectProfile extends ConsumerWidget {
@@ -9,23 +16,37 @@ class MissionFeedSelectProfile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Padding(
-      padding: EdgeInsets.symmetric(horizontal: 8.0),
-      child: Column(
-        children: [
-          FarmclubSelectProfile(
-            image: '',
-            size: 64,
-          ),
-          SizedBox(
-            height: 8.0,
-          ),
-          Text(
-            '파머시치',
-            style: FarmusThemeTextStyle.gray1Medium11,
-          ),
-        ],
-      ),
-    );
+    final AsyncValue<List<MyFarmclubModel>> myFarmclub =
+        ref.watch(myFarmclubModelProvider);
+    final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
+    final AsyncValue<MyFarmclubInfoModel> myFarmclubInfo = ref.watch(
+        myFarmclubInfoModelProvider(
+            selectedFarmclubId ?? myFarmclub.value?.first.farmClubId));
+    final nickName = ref.watch(onBoardingFinishNotifierProvider);
+
+    return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: myFarmclubInfo.when(
+          data: (farmclubInfo) {
+            return Column(
+              children: [
+                FarmclubSelectProfile(
+                  image: farmclubInfo.farmClubImage,
+                  size: 64,
+                ),
+                const SizedBox(
+                  height: 8.0,
+                ),
+                Text(
+                  '${nickName.value}',
+                  style: FarmusThemeTextStyle.gray1Medium11,
+                ),
+              ],
+            );
+          },
+          loading: () => const CircularProgressIndicator(),
+          error: (error, stack) =>
+              SvgPicture.asset('assets/image/ic_alert_circle.svg'),
+        ));
   }
 }

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -46,8 +46,6 @@ class MissionFeedTabBar extends ConsumerWidget {
         ),
       ),
     ];
-
-    // Dynamic steps tab views
     for (var step in farmclubInfo.steps) {
       tabViews.add(
         SingleChildScrollView(
@@ -56,8 +54,7 @@ class MissionFeedTabBar extends ConsumerWidget {
             child: Column(
               children: [
                 MissionStepInfo(
-                  stepNum: step.stepNum,
-                  stepName: step.stepName,
+                  step: step,
                   isButton: true,
                 ),
                 if (step.stepNum == farmclubInfo.steps.last.stepNum)

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -1,134 +1,80 @@
-import 'package:farmus/view/mission_feed/component/mission_feed_basic_profile.dart';
-import 'package:farmus/view/mission_feed/component/mission_feed_select_profile.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../common/tab_bar/primary_tab_bar.dart';
+import '../../../model/my_farmclub/my_farmclub_info_model.dart';
 import '../../farmclub/component/farmclub_feed.dart';
 import '../../mission_write/component/mission_step_info.dart';
+import 'mission_feed_basic_profile.dart';
+import 'mission_feed_select_profile.dart';
 
 class MissionFeedTabBar extends ConsumerWidget {
-  const MissionFeedTabBar({super.key});
+  const MissionFeedTabBar({super.key, required this.farmclubInfo});
+
+  final MyFarmclubInfoModel farmclubInfo;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const PrimaryTabBar(
-      tab: ['전체', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5'],
-      tabView: [
-        SingleChildScrollView(
-          child: Column(
-            children: [
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 16.0),
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: Row(
-                    children: [
-                      MissionFeedSelectProfile(),
-                      MissionFeedBasicProfile(
-                        nickname: '감자',
-                      ),
-                      MissionFeedBasicProfile(
-                        nickname: '홈프로텍터',
-                      ),
-                      MissionFeedBasicProfile(
-                        nickname: '갓팜',
-                      ),
-                      MissionFeedBasicProfile(
-                        nickname: '푸우',
-                      ),
-                      MissionFeedBasicProfile(
-                        nickname: '종강언제함',
-                      ),
-                      MissionFeedBasicProfile(
-                        nickname: '배고파',
-                      ),
-                    ],
-                  ),
+    List<Widget> tabViews = [
+      const SingleChildScrollView(
+        child: Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 16.0),
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: Row(
+                  children: [
+                    MissionFeedSelectProfile(),
+                    MissionFeedBasicProfile(nickname: '감자'),
+                    MissionFeedBasicProfile(nickname: '홈프로텍터'),
+                    MissionFeedBasicProfile(nickname: '갓팜'),
+                    MissionFeedBasicProfile(nickname: '푸우'),
+                    MissionFeedBasicProfile(nickname: '종강언제함'),
+                    MissionFeedBasicProfile(nickname: '배고파'),
+                  ],
                 ),
               ),
-              Padding(
-                padding: EdgeInsets.symmetric(horizontal: 16.0),
-                child: Column(children: [
-                ],),
-              )
-            ],
-          ),
+            ),
+            Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: Column(
+                children: [],
+              ),
+            ),
+          ],
         ),
+      ),
+    ];
+
+    // Dynamic steps tab views
+    for (var step in farmclubInfo.steps) {
+      tabViews.add(
         SingleChildScrollView(
           child: Padding(
-            padding: EdgeInsets.all(16.0),
+            padding: const EdgeInsets.all(16.0),
             child: Column(
               children: [
                 MissionStepInfo(
-                  stepNum: 1,
+                  stepNum: step.stepNum,
+                  stepName: step.stepName,
                   isButton: true,
                 ),
+                if (step.stepNum == farmclubInfo.steps.last.stepNum)
+                  FarmclubFeed(
+                    farmclubInfoModel: farmclubInfo,
+                  ),
               ],
             ),
           ),
         ),
-        SingleChildScrollView(
-          child: Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                MissionStepInfo(
-                  stepNum: 2,
-                  isButton: true,
-                ),
-              ],
-            ),
-          ),
-        ),
-        SingleChildScrollView(
-          child: Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                MissionStepInfo(
-                  stepNum: 3,
-                  isButton: true,
-                ),
-                // FarmclubFeed(),
-                // FarmclubFeed(),
-                // FarmclubFeed(),
-                // FarmclubFeed(),
-              ],
-            ),
-          ),
-        ),
-        SingleChildScrollView(
-          child: Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                MissionStepInfo(
-                  stepNum: 4,
-                  isButton: true,
-                ),
-              ],
-            ),
-          ),
-        ),
-        SingleChildScrollView(
-          child: Padding(
-            padding: EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                MissionStepInfo(
-                  stepNum: 5,
-                  isButton: true,
-                ),
-                // FarmclubFeed(),
-                // FarmclubFeed(),
-                // FarmclubFeed(),
-                // FarmclubFeed(),
-              ],
-            ),
-          ),
-        ),
-      ],
+      );
+    }
+
+    return PrimaryTabBar(
+      tab: ['전체'] +
+          farmclubInfo.steps.map((step) => 'Step ${step.stepNum + 1}').toList(),
+      tabView: tabViews,
     );
   }
 }

--- a/lib/view/mission_feed/mission_feed_screen.dart
+++ b/lib/view/mission_feed/mission_feed_screen.dart
@@ -1,17 +1,22 @@
 import 'package:farmus/common/app_bar/back_left_title_app_bar.dart';
+import 'package:farmus/model/my_farmclub/my_farmclub_info_model.dart';
 import 'package:farmus/view/mission_feed/component/mission_feed_tab_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class MissionFeedScreen extends ConsumerWidget {
-  const MissionFeedScreen({super.key});
+  const MissionFeedScreen({super.key, required this.farmclubInfo});
+
+  final MyFarmclubInfoModel farmclubInfo;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(
-        appBar: BackLeftTitleAppBar(
+    return Scaffold(
+        appBar: const BackLeftTitleAppBar(
           title: '미션 피드',
         ),
-        body: MissionFeedTabBar());
+        body: MissionFeedTabBar(
+          farmclubInfo: farmclubInfo,
+        ));
   }
 }

--- a/lib/view/mission_write/component/mission_step_info.dart
+++ b/lib/view/mission_write/component/mission_step_info.dart
@@ -7,9 +7,13 @@ import 'mission_write_route_button.dart';
 
 class MissionStepInfo extends ConsumerWidget {
   const MissionStepInfo(
-      {super.key, required this.stepNum, required this.isButton});
+      {super.key,
+      required this.stepNum,
+      required this.stepName,
+      required this.isButton});
 
   final int stepNum;
+  final String stepName;
   final bool isButton;
 
   @override
@@ -27,23 +31,28 @@ class MissionStepInfo extends ConsumerWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                'Step $stepNum',
-                style: FarmusThemeTextStyle.gray2SemiBold13,
-              ),
-              const SizedBox(
-                height: 8.0,
-              ),
-              const Text(
-                '준비물을 챙겨요',
-                style: FarmusThemeTextStyle.darkSemiBold15,
-              ),
-            ],
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Step ${stepNum + 1}',
+                  style: FarmusThemeTextStyle.gray2SemiBold13,
+                ),
+                const SizedBox(
+                  height: 8.0,
+                ),
+                Text(
+                  stepName,
+                  style: FarmusThemeTextStyle.darkSemiBold15,
+                ),
+              ],
+            ),
           ),
-           MissionWriteRouteButton(isButton: isButton)
+          const SizedBox(
+            width: 8.0,
+          ),
+          MissionWriteRouteButton(isButton: isButton)
         ],
       ),
     );

--- a/lib/view/mission_write/component/mission_step_info.dart
+++ b/lib/view/mission_write/component/mission_step_info.dart
@@ -1,3 +1,4 @@
+import 'package:farmus/model/my_farmclub/my_farmclub_info_model.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,13 +8,9 @@ import 'mission_write_route_button.dart';
 
 class MissionStepInfo extends ConsumerWidget {
   const MissionStepInfo(
-      {super.key,
-      required this.stepNum,
-      required this.stepName,
-      required this.isButton});
+      {super.key, required this.step, required this.isButton});
 
-  final int stepNum;
-  final String stepName;
+  final StepModel step;
   final bool isButton;
 
   @override
@@ -36,14 +33,14 @@ class MissionStepInfo extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  'Step ${stepNum + 1}',
+                  'Step ${step.stepNum + 1}',
                   style: FarmusThemeTextStyle.gray2SemiBold13,
                 ),
                 const SizedBox(
                   height: 8.0,
                 ),
                 Text(
-                  stepName,
+                  step.stepName,
                   style: FarmusThemeTextStyle.darkSemiBold15,
                 ),
               ],
@@ -52,7 +49,7 @@ class MissionStepInfo extends ConsumerWidget {
           const SizedBox(
             width: 8.0,
           ),
-          MissionWriteRouteButton(isButton: isButton)
+          MissionWriteRouteButton(step: step, isButton: isButton)
         ],
       ),
     );

--- a/lib/view/mission_write/component/mission_write_route_button.dart
+++ b/lib/view/mission_write/component/mission_write_route_button.dart
@@ -1,3 +1,4 @@
+import 'package:farmus/model/my_farmclub/my_farmclub_info_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -6,8 +7,10 @@ import '../../../common/theme/farmus_theme_text_style.dart';
 import '../mission_write_screen.dart';
 
 class MissionWriteRouteButton extends ConsumerWidget {
-  const MissionWriteRouteButton({super.key, required this.isButton});
+  const MissionWriteRouteButton(
+      {super.key, required this.step, required this.isButton});
 
+  final StepModel step;
   final bool isButton;
 
   @override
@@ -19,8 +22,8 @@ class MissionWriteRouteButton extends ConsumerWidget {
           Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (builder) => const MissionWriteScreen(
-                stepNum: 3,
+              builder: (builder) => MissionWriteScreen(
+                step: step,
               ),
             ),
           );

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -52,6 +52,7 @@ class MissionWriteScreen extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: MissionStepInfo(
                 stepNum: stepNum,
+                stepName: '더미더미더미더미',
                 isButton: false,
               ),
             ),

--- a/lib/view/mission_write/mission_write_screen.dart
+++ b/lib/view/mission_write/mission_write_screen.dart
@@ -1,5 +1,6 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
 import 'package:farmus/common/button/primary_color_button.dart';
+import 'package:farmus/model/my_farmclub/my_farmclub_info_model.dart';
 import 'package:farmus/view/mission_write/component/mission_step_info.dart';
 import 'package:farmus/view_model/mission_write/mission_write_provider.dart';
 import 'package:flutter/material.dart';
@@ -10,9 +11,9 @@ import '../../common/form/content_input_text_form.dart';
 import '../../common/image_picker/write_image_picker.dart';
 
 class MissionWriteScreen extends ConsumerWidget {
-  const MissionWriteScreen({super.key, required this.stepNum});
+  const MissionWriteScreen({super.key, required this.step});
 
-  final int stepNum;
+  final StepModel step;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -33,7 +34,7 @@ class MissionWriteScreen extends ConsumerWidget {
                     Navigator.of(context).pop();
                   });
                   return CheckDialog(
-                    text: "Step $stepNum 미션을 인증했어요",
+                    text: "Step ${step.stepNum + 1} 미션을 인증했어요",
                   );
                 },
               );
@@ -51,8 +52,7 @@ class MissionWriteScreen extends ConsumerWidget {
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: MissionStepInfo(
-                stepNum: stepNum,
-                stepName: '더미더미더미더미',
+                step: step,
                 isButton: false,
               ),
             ),

--- a/lib/view/my_farmclub/component/farmclub_profile.dart
+++ b/lib/view/my_farmclub/component/farmclub_profile.dart
@@ -11,7 +11,7 @@ import '../../../model/my_farmclub/my_farmclub_model.dart';
 class FarmclubProfile extends ConsumerWidget {
   final MyFarmclubModel? farmclub;
 
-  const FarmclubProfile({Key? key, this.farmclub}) : super(key: key);
+  const FarmclubProfile({super.key, this.farmclub});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/lib/view/on_boarding/on_boarding_finish_screen.dart
+++ b/lib/view/on_boarding/on_boarding_finish_screen.dart
@@ -11,7 +11,7 @@ class OnBoardingFinishScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final asyncNickName = ref.watch(onBoardingFinishNotifierProvider);
+    final nickName = ref.watch(onBoardingFinishNotifierProvider);
 
     ref.read(onBoardingFinishNotifierProvider.notifier).onBoardingComplete();
 
@@ -20,12 +20,12 @@ class OnBoardingFinishScreen extends ConsumerWidget {
         leading: Container(),
         title: null,
       ),
-      body: asyncNickName.when(
+      body: nickName.when(
         data: (nickName) => Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Padding(
-              padding: EdgeInsets.all(16.0),
+              padding: const EdgeInsets.all(16.0),
               child: MainSubTitle(
                 mainText: "$nickName 님의 가입이 완료되었어요!",
                 subText: "홈에서 추천 채소를 확인해보세요.",

--- a/lib/view/tip/component/tip_expand_card.dart
+++ b/lib/view/tip/component/tip_expand_card.dart
@@ -3,9 +3,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../common/theme/farmus_theme_color.dart';
 import '../../../common/theme/farmus_theme_text_style.dart';
+import '../../../model/search/farmclub_help_info_model.dart';
 
 class TipExpandCard extends ConsumerWidget {
-  const TipExpandCard({super.key});
+  const TipExpandCard({super.key, required this.helpInfoModel});
+
+  final FarmclubHelpInfoModel helpInfoModel;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -24,67 +27,78 @@ class TipExpandCard extends ConsumerWidget {
             height: 40,
             decoration: ShapeDecoration(
               color: FarmusThemeColor.black,
-              image: null,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(30),
               ),
             ),
           ),
-          title: const Column(
+          title: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
+              const Text(
                 '준비물',
                 style: FarmusThemeTextStyle.gray2Medium13,
               ),
-              SizedBox(
+              const SizedBox(
                 height: 8.0,
               ),
               Text(
-                '흙대파, 상토, 재사용 흙, 재배 용기',
+                helpInfoModel.material,
                 style: FarmusThemeTextStyle.darkMedium15,
               ),
             ],
           ),
-          children: const [
+          children: [
             ListTile(
-              leading: SizedBox(
+              leading: const SizedBox(
                 width: 40,
               ),
               title: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
+                  const Text(
                     '고르는 법',
                     style: FarmusThemeTextStyle.gray2Medium13,
                   ),
-                  SizedBox(
+                  const SizedBox(
                     height: 8.0,
                   ),
-                  Text(
-                    '뿌리가 튼튼하게 달려있어요\n너무 가는 것은 순이 여러 번 나오지 못해요\n너무 굵은 것은 맛이 덜해요',
-                    style: FarmusThemeTextStyle.darkMedium15,
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children:
+                        List.generate(helpInfoModel.selectHow.length, (index) {
+                      return Text(
+                        helpInfoModel.selectHow[index],
+                        style: FarmusThemeTextStyle.darkMedium15,
+                      );
+                    }),
                   ),
                 ],
               ),
             ),
             ListTile(
-              leading: SizedBox(
+              leading: const SizedBox(
                 width: 40,
               ),
               title: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
+                  const Text(
                     '특징',
                     style: FarmusThemeTextStyle.gray2Medium13,
                   ),
-                  SizedBox(
+                  const SizedBox(
                     height: 8.0,
                   ),
-                  Text(
-                    '심고 일주일만 기다리면 먹을 수 있어요\n장마철에 키우기 어려워요',
-                    style: FarmusThemeTextStyle.darkMedium15,
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children:
+                        List.generate(helpInfoModel.features.length, (index) {
+                      return Text(
+                        helpInfoModel.features[index],
+                        style: FarmusThemeTextStyle.darkMedium15,
+                      );
+                    }),
                   ),
                 ],
               ),

--- a/lib/view/tip/component/tip_step_text.dart
+++ b/lib/view/tip/component/tip_step_text.dart
@@ -19,8 +19,10 @@ class TipStepText extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               'Step $stepIndex',
@@ -29,10 +31,12 @@ class TipStepText extends ConsumerWidget {
             const SizedBox(
               width: 8,
             ),
-            Text(
-              stepTitle,
-              style: FarmusThemeTextStyle.darkSemiBold17,
-            )
+            Expanded(
+              child: Text(
+                stepTitle,
+                style: FarmusThemeTextStyle.darkSemiBold17,
+              ),
+            ),
           ],
         ),
         const SizedBox(
@@ -42,6 +46,7 @@ class TipStepText extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.only(bottom: 8.0),
             child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Container(
                   width: 16,
@@ -52,24 +57,21 @@ class TipStepText extends ConsumerWidget {
                       borderRadius: BorderRadius.circular(21),
                     ),
                   ),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    crossAxisAlignment: CrossAxisAlignment.center,
-                    children: [
-                      Text(
-                        '${entry.key}',
-                        style: FarmusThemeTextStyle.whiteMedium10,
-                      ),
-                    ],
+                  child: Center(
+                    child: Text(
+                      '${entry.key}',
+                      style: FarmusThemeTextStyle.whiteMedium10,
+                    ),
                   ),
                 ),
                 const SizedBox(
                   width: 8.0,
                 ),
-                Text(
-                  entry.value,
-                  style: FarmusThemeTextStyle.darkMedium15,
+                Expanded(
+                  child: Text(
+                    entry.value,
+                    style: FarmusThemeTextStyle.darkMedium15,
+                  ),
                 ),
               ],
             ),

--- a/lib/view/tip/component/tip_step_text.dart
+++ b/lib/view/tip/component/tip_step_text.dart
@@ -46,7 +46,7 @@ class TipStepText extends ConsumerWidget {
           Padding(
             padding: const EdgeInsets.only(bottom: 8.0),
             child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Container(
                   width: 16,

--- a/lib/view/tip/tip_screen.dart
+++ b/lib/view/tip/tip_screen.dart
@@ -16,7 +16,7 @@ class TipScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
     final AsyncValue<FarmclubHelpModel> farmclubHelp =
-    ref.watch(farmclubHelpModelProvider(selectedFarmclubId));
+        ref.watch(farmclubHelpModelProvider(selectedFarmclubId));
 
     return Scaffold(
       appBar: const DeleteAppBar(
@@ -29,15 +29,18 @@ class TipScreen extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+                  padding:
+                      EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
                   child: Text(
                     '대파 키우기',
                     style: FarmusThemeTextStyle.darkSemiBold21,
                   ),
                 ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16.0),
-                  child: TipExpandCard(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: TipExpandCard(
+                    helpInfoModel: helpModel.farmclubHelpInfoModel,
+                  ),
                 ),
                 const SizedBox(
                   height: 32.0,
@@ -53,7 +56,10 @@ class TipScreen extends ConsumerWidget {
                       child: TipStepText(
                         stepIndex: step.num + 1,
                         stepTitle: step.content,
-                        detailStep: {for (var i = 0; i < step.tips.length; i++) i + 1: step.tips[i]},
+                        detailStep: {
+                          for (var i = 0; i < step.tips.length; i++)
+                            i + 1: step.tips[i]
+                        },
                       ),
                     );
                   },

--- a/lib/view/tip/tip_screen.dart
+++ b/lib/view/tip/tip_screen.dart
@@ -1,9 +1,12 @@
 import 'package:farmus/common/app_bar/delete_app_bar.dart';
+import 'package:farmus/model/my_farmclub/farmclub_help_model.dart';
 import 'package:farmus/view/tip/component/tip_expand_card.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../common/theme/farmus_theme_text_style.dart';
+import '../../view_model/home/home_provider.dart';
+import '../../view_model/my_farmclub/farmclub_help_notifier.dart';
 import 'component/tip_step_text.dart';
 
 class TipScreen extends ConsumerWidget {
@@ -11,45 +14,56 @@ class TipScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
+    final AsyncValue<FarmclubHelpModel> farmclubHelp =
+    ref.watch(farmclubHelpModelProvider(selectedFarmclubId));
+
     return Scaffold(
       appBar: const DeleteAppBar(
         title: '도움말',
       ),
-      body: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
-              child: Text(
-                '대파 키우기',
-                style: FarmusThemeTextStyle.darkSemiBold21,
-              ),
-            ),
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16.0),
-              child: TipExpandCard(),
-            ),
-            const SizedBox(
-              height: 32.0,
-            ),
-            ListView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              itemCount: 5,
-              itemBuilder: (context, index) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: TipStepText(
-                    stepIndex: index + 1,
-                    stepTitle: '대파를 심어요',
-                    detailStep: const {1: '1번', 2: '2번', 3: '3번'},
+      body: farmclubHelp.when(
+        data: (helpModel) {
+          return SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 16.0),
+                  child: Text(
+                    '대파 키우기',
+                    style: FarmusThemeTextStyle.darkSemiBold21,
                   ),
-                );
-              },
+                ),
+                const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16.0),
+                  child: TipExpandCard(),
+                ),
+                const SizedBox(
+                  height: 32.0,
+                ),
+                ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: helpModel.steps.length,
+                  itemBuilder: (context, index) {
+                    final step = helpModel.steps[index];
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                      child: TipStepText(
+                        stepIndex: step.num + 1,
+                        stepTitle: step.content,
+                        detailStep: {for (var i = 0; i < step.tips.length; i++) i + 1: step.tips[i]},
+                      ),
+                    );
+                  },
+                ),
+              ],
             ),
-          ],
-        ),
+          );
+        },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (error, stack) => Center(child: Text('Error: $error')),
       ),
     );
   }

--- a/lib/view/vege_diary/vege_diary_screen.dart
+++ b/lib/view/vege_diary/vege_diary_screen.dart
@@ -17,7 +17,7 @@ class VegeDiaryScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var selectedVeggieId = ref.watch(selectedVeggieIdProvider);
+    var selectedVeggieId = ref.watch(selectedVegeIdProvider);
     final AsyncValue<List<MyVeggieListModel>> veggieList =
         ref.watch(myVeggieListModelProvider);
 

--- a/lib/view/vege_diary_write/component/vege_diary_write_state.dart
+++ b/lib/view/vege_diary_write/component/vege_diary_write_state.dart
@@ -46,6 +46,7 @@ class VegeDiaryWriteState extends ConsumerWidget {
                         notifier.updateVegeState('나쁨');
                       },
                       fontPadding: 0,
+                      padding: 0,
                     ),
                     HomeMyVegeButton(
                       enabled: vegeState == '보통',
@@ -54,6 +55,7 @@ class VegeDiaryWriteState extends ConsumerWidget {
                         notifier.updateVegeState('보통');
                       },
                       fontPadding: 0,
+                      padding: 0,
                     ),
                     HomeMyVegeButton(
                       enabled: vegeState == '좋음',
@@ -62,6 +64,7 @@ class VegeDiaryWriteState extends ConsumerWidget {
                         notifier.updateVegeState('좋음');
                       },
                       fontPadding: 0,
+                      padding: 0,
                     ),
                   ],
                 )

--- a/lib/view/vege_diary_write/vege_diary_write_screen.dart
+++ b/lib/view/vege_diary_write/vege_diary_write_screen.dart
@@ -26,7 +26,7 @@ class VegeDiaryWriteScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    var selectedVeggieId = ref.watch(selectedVeggieIdProvider);
+    var selectedVeggieId = ref.watch(selectedVegeIdProvider);
     final AsyncValue<List<MyVeggieListModel>> veggieList =
         ref.watch(myVeggieListModelProvider);
 

--- a/lib/view_model/home/home_provider.dart
+++ b/lib/view_model/home/home_provider.dart
@@ -5,5 +5,5 @@ final homeToDoProvider = StateNotifierProvider<ToDoNotifier, String>((ref) {
   return ToDoNotifier();
 });
 
-final selectedVeggieIdProvider = StateProvider<int?>((ref) => null);
+final selectedVegeIdProvider = StateProvider<int?>((ref) => null);
 final selectedFarmclubIdProvider = StateProvider<int?>((ref) => null);

--- a/lib/view_model/my_farmclub/farmclub_help_notifier.dart
+++ b/lib/view_model/my_farmclub/farmclub_help_notifier.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:farmus/repository/my_farmclub_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../model/my_farmclub/farmclub_help_model.dart';
+import 'my_farmclub_notifier.dart';
+
+part 'farmclub_help_notifier.g.dart';
+
+@riverpod
+Future<FarmclubHelpModel> farmclubHelpModel(
+    FarmclubHelpModelRef ref, int? farmclubId) async {
+  if (farmclubId == null) {
+    final farmclubs = await ref.watch(myFarmclubModelProvider.future);
+    farmclubId = farmclubs.first.farmClubId.toInt();
+  }
+
+  final response = await MyFarmclubRepository.farmclubHelp(farmclubId);
+  final json = jsonDecode(response) as Map<String, dynamic>;
+
+  final farmclubHelpModel =
+      FarmclubHelpModel.fromJson(json['data'] as Map<String, dynamic>);
+  return farmclubHelpModel;
+}

--- a/lib/view_model/my_farmclub/farmclub_help_notifier.dart
+++ b/lib/view_model/my_farmclub/farmclub_help_notifier.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
 
+import 'package:farmus/model/my_farmclub/farmclub_help_model.dart';
 import 'package:farmus/repository/my_farmclub_repository.dart';
+import 'package:farmus/view_model/my_farmclub/my_farmclub_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../model/my_farmclub/farmclub_help_model.dart';
-import 'my_farmclub_notifier.dart';
+import '../../model/search/farmclub_help_info_model.dart';
 
 part 'farmclub_help_notifier.g.dart';
 
@@ -19,7 +20,24 @@ Future<FarmclubHelpModel> farmclubHelpModel(
   final response = await MyFarmclubRepository.farmclubHelp(farmclubId);
   final json = jsonDecode(response) as Map<String, dynamic>;
 
-  final farmclubHelpModel =
-      FarmclubHelpModel.fromJson(json['data'] as Map<String, dynamic>);
-  return farmclubHelpModel;
+  if (json['data'] == null) {
+    throw Exception("데이터가 없습니다.");
+  }
+
+  final data = json['data'] as Map<String, dynamic>;
+
+  if (data['help'] == null || data['steps'] == null) {
+    throw Exception("도움말이 없습니다.");
+  }
+
+  final farmclubHelpInfoModel =
+      FarmclubHelpInfoModel.fromJson(data['help'] as Map<String, dynamic>);
+  final steps = (data['steps'] as List<dynamic>)
+      .map((e) => HelpStep.fromJson(e as Map<String, dynamic>))
+      .toList();
+
+  return FarmclubHelpModel(
+    farmclubHelpInfoModel: farmclubHelpInfoModel,
+    steps: steps,
+  );
 }

--- a/lib/view_model/my_farmclub/farmclub_help_notifier.g.dart
+++ b/lib/view_model/my_farmclub/farmclub_help_notifier.g.dart
@@ -1,0 +1,160 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'farmclub_help_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$farmclubHelpModelHash() => r'f3ae736b404d3827d09c9dd152da1a88de0b7dd2';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [farmclubHelpModel].
+@ProviderFor(farmclubHelpModel)
+const farmclubHelpModelProvider = FarmclubHelpModelFamily();
+
+/// See also [farmclubHelpModel].
+class FarmclubHelpModelFamily extends Family<AsyncValue<FarmclubHelpModel>> {
+  /// See also [farmclubHelpModel].
+  const FarmclubHelpModelFamily();
+
+  /// See also [farmclubHelpModel].
+  FarmclubHelpModelProvider call(
+    int? farmclubId,
+  ) {
+    return FarmclubHelpModelProvider(
+      farmclubId,
+    );
+  }
+
+  @override
+  FarmclubHelpModelProvider getProviderOverride(
+    covariant FarmclubHelpModelProvider provider,
+  ) {
+    return call(
+      provider.farmclubId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'farmclubHelpModelProvider';
+}
+
+/// See also [farmclubHelpModel].
+class FarmclubHelpModelProvider
+    extends AutoDisposeFutureProvider<FarmclubHelpModel> {
+  /// See also [farmclubHelpModel].
+  FarmclubHelpModelProvider(
+    int? farmclubId,
+  ) : this._internal(
+          (ref) => farmclubHelpModel(
+            ref as FarmclubHelpModelRef,
+            farmclubId,
+          ),
+          from: farmclubHelpModelProvider,
+          name: r'farmclubHelpModelProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$farmclubHelpModelHash,
+          dependencies: FarmclubHelpModelFamily._dependencies,
+          allTransitiveDependencies:
+              FarmclubHelpModelFamily._allTransitiveDependencies,
+          farmclubId: farmclubId,
+        );
+
+  FarmclubHelpModelProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.farmclubId,
+  }) : super.internal();
+
+  final int? farmclubId;
+
+  @override
+  Override overrideWith(
+    FutureOr<FarmclubHelpModel> Function(FarmclubHelpModelRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: FarmclubHelpModelProvider._internal(
+        (ref) => create(ref as FarmclubHelpModelRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        farmclubId: farmclubId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<FarmclubHelpModel> createElement() {
+    return _FarmclubHelpModelProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FarmclubHelpModelProvider && other.farmclubId == farmclubId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, farmclubId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin FarmclubHelpModelRef on AutoDisposeFutureProviderRef<FarmclubHelpModel> {
+  /// The parameter `farmclubId` of this provider.
+  int? get farmclubId;
+}
+
+class _FarmclubHelpModelProviderElement
+    extends AutoDisposeFutureProviderElement<FarmclubHelpModel>
+    with FarmclubHelpModelRef {
+  _FarmclubHelpModelProviderElement(super.provider);
+
+  @override
+  int? get farmclubId => (origin as FarmclubHelpModelProvider).farmclubId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/my_farmclub/farmclub_help_notifier.g.dart
+++ b/lib/view_model/my_farmclub/farmclub_help_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'farmclub_help_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$farmclubHelpModelHash() => r'f3ae736b404d3827d09c9dd152da1a88de0b7dd2';
+String _$farmclubHelpModelHash() => r'b4c534e4f8b82d714e42b7ef6ee34ccbbfbfeb19';
 
 /// Copied from Dart SDK
 class _SystemHash {

--- a/lib/view_model/my_farmclub/farmclub_mission_certification_notifier.dart
+++ b/lib/view_model/my_farmclub/farmclub_mission_certification_notifier.dart
@@ -1,0 +1,21 @@
+import 'package:farmus/repository/my_farmclub_repository.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../model/mission/mission_write_model.dart';
+
+part 'farmclub_mission_certification_notifier.g.dart';
+
+@riverpod
+class FarmclubMissionCertificationNotifier
+    extends _$FarmclubMissionCertificationNotifier {
+  @override
+  Future<MissionWriteModel> build() async {
+    return MissionWriteModel(content: '', image: XFile(''), isComplete: false);
+  }
+
+  Future<void> postMissionCertification(
+      MissionWriteModel mission, int farmclubId, int stepNum) async {
+    await MyFarmclubRepository.farmclubMissionCertification(mission, 5, 1);
+  }
+}

--- a/lib/view_model/my_farmclub/farmclub_mission_certification_notifier.g.dart
+++ b/lib/view_model/my_farmclub/farmclub_mission_certification_notifier.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'farmclub_mission_certification_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$farmclubMissionCertificationNotifierHash() =>
+    r'21d00dc99122f7cc3c4170cca4db732642c600f7';
+
+/// See also [FarmclubMissionCertificationNotifier].
+@ProviderFor(FarmclubMissionCertificationNotifier)
+final farmclubMissionCertificationNotifierProvider =
+    AutoDisposeAsyncNotifierProvider<FarmclubMissionCertificationNotifier,
+        MissionWriteModel>.internal(
+  FarmclubMissionCertificationNotifier.new,
+  name: r'farmclubMissionCertificationNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$farmclubMissionCertificationNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$FarmclubMissionCertificationNotifier
+    = AutoDisposeAsyncNotifier<MissionWriteModel>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/on_boarding/on_boarding_finish_notifier.dart
+++ b/lib/view_model/on_boarding/on_boarding_finish_notifier.dart
@@ -14,9 +14,7 @@ class OnBoardingFinishNotifier extends _$OnBoardingFinishNotifier {
 
   Future<String> fetchNickName() async {
     final response = await UserRepository.userInfo();
-    print('fetchNickName response: $response');
     var jsonResponse = convert.jsonDecode(response) as Map<String, dynamic>;
-    print('jsonResponse: $jsonResponse');
 
     if (jsonResponse['data'] == null) {
       throw Exception('Data is null');
@@ -25,7 +23,6 @@ class OnBoardingFinishNotifier extends _$OnBoardingFinishNotifier {
       throw Exception('NickName is null');
     }
 
-    print(jsonResponse['data']['nickName']);
     return jsonResponse['data']['nickName'];
   }
 
@@ -34,7 +31,6 @@ class OnBoardingFinishNotifier extends _$OnBoardingFinishNotifier {
   }
 
   Future<void> onBoardingComplete() async {
-    final response = await UserRepository.onBoardingComplete();
-    print(response);
+    await UserRepository.onBoardingComplete();
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -277,10 +277,18 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "11e40df547d418cc0c4900a9318b26304e665da6fa4755399a9ff9efd09034b5"
+      sha256: "77befdddf51050e1635a04d2bcfff230089ce7294e642d00da58cd079c0de0c8"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.3+1"
+    version: "5.5.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "36c5b2d79eb17cdae41e974b7a8284fec631651d2a6f39a8a2ff22327e90aeac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   dots_indicator:
     dependency: "direct main"
     description:
@@ -545,10 +553,10 @@ packages:
     dependency: "direct main"
     description:
       name: freezed_annotation
-      sha256: c3fd9336eb55a38cc1bbd79ab17573113a8deccd0ecbbf926cca3c62803b5c2d
+      sha256: f54946fdb1fa7b01f780841937b1a80783a20b393485f3f6cdf336fd6f4705f2
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   frontend_server_client:
     dependency: transitive
     description:


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #208 


### 🍠 Summary

- 도움말 연동
- 미션 인증, 미션 목록 피드 service단 까지 구현, 매핑은 아직
- 미션 피드에서 유저 닉네임, 채소 사진 조회
- 미션 피드 스텝 연동
- 미션 인증하기 버튼 누르면 해당 스텝넘버, 스텝이름 정보 받아오기 연동


https://github.com/Mojacknong/Farmus_App/assets/97820109/99f99a71-90ca-45ad-bcab-0467aa05c3f7



### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information

미션 피드에서 유저 닉네임을 바로 조회해오는데,
이 로직처럼 notifier 바로 이용해서 마이페이지, 탐색창도 닉네임 받아올 수 있을 것 같아용