### PR TITLE
[Feat] 미션 목록 Step 구분하여 조회하기

### DIFF
--- a/lib/model/my_farmclub/mission_feed.dart
+++ b/lib/model/my_farmclub/mission_feed.dart
@@ -7,9 +7,10 @@ part 'mission_feed.g.dart';
 class MissionFeed with _$MissionFeed {
   const factory MissionFeed({
     required int missionPostId,
+    required int stepNum,
     required String nickname,
     required String profileImage,
-    required DateTime date,
+    required String date,
     required String image,
     required String content,
     required int likeCount,

--- a/lib/model/my_farmclub/mission_feed.freezed.dart
+++ b/lib/model/my_farmclub/mission_feed.freezed.dart
@@ -21,9 +21,10 @@ MissionFeed _$MissionFeedFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$MissionFeed {
   int get missionPostId => throw _privateConstructorUsedError;
+  int get stepNum => throw _privateConstructorUsedError;
   String get nickname => throw _privateConstructorUsedError;
   String get profileImage => throw _privateConstructorUsedError;
-  DateTime get date => throw _privateConstructorUsedError;
+  String get date => throw _privateConstructorUsedError;
   String get image => throw _privateConstructorUsedError;
   String get content => throw _privateConstructorUsedError;
   int get likeCount => throw _privateConstructorUsedError;
@@ -44,9 +45,10 @@ abstract class $MissionFeedCopyWith<$Res> {
   @useResult
   $Res call(
       {int missionPostId,
+      int stepNum,
       String nickname,
       String profileImage,
-      DateTime date,
+      String date,
       String image,
       String content,
       int likeCount,
@@ -68,6 +70,7 @@ class _$MissionFeedCopyWithImpl<$Res, $Val extends MissionFeed>
   @override
   $Res call({
     Object? missionPostId = null,
+    Object? stepNum = null,
     Object? nickname = null,
     Object? profileImage = null,
     Object? date = null,
@@ -82,6 +85,10 @@ class _$MissionFeedCopyWithImpl<$Res, $Val extends MissionFeed>
           ? _value.missionPostId
           : missionPostId // ignore: cast_nullable_to_non_nullable
               as int,
+      stepNum: null == stepNum
+          ? _value.stepNum
+          : stepNum // ignore: cast_nullable_to_non_nullable
+              as int,
       nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
@@ -93,7 +100,7 @@ class _$MissionFeedCopyWithImpl<$Res, $Val extends MissionFeed>
       date: null == date
           ? _value.date
           : date // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as String,
       image: null == image
           ? _value.image
           : image // ignore: cast_nullable_to_non_nullable
@@ -128,9 +135,10 @@ abstract class _$$MissionFeedImplCopyWith<$Res>
   @useResult
   $Res call(
       {int missionPostId,
+      int stepNum,
       String nickname,
       String profileImage,
-      DateTime date,
+      String date,
       String image,
       String content,
       int likeCount,
@@ -150,6 +158,7 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? missionPostId = null,
+    Object? stepNum = null,
     Object? nickname = null,
     Object? profileImage = null,
     Object? date = null,
@@ -164,6 +173,10 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
           ? _value.missionPostId
           : missionPostId // ignore: cast_nullable_to_non_nullable
               as int,
+      stepNum: null == stepNum
+          ? _value.stepNum
+          : stepNum // ignore: cast_nullable_to_non_nullable
+              as int,
       nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
@@ -175,7 +188,7 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
       date: null == date
           ? _value.date
           : date // ignore: cast_nullable_to_non_nullable
-              as DateTime,
+              as String,
       image: null == image
           ? _value.image
           : image // ignore: cast_nullable_to_non_nullable
@@ -205,6 +218,7 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
 class _$MissionFeedImpl implements _MissionFeed {
   const _$MissionFeedImpl(
       {required this.missionPostId,
+      required this.stepNum,
       required this.nickname,
       required this.profileImage,
       required this.date,
@@ -220,11 +234,13 @@ class _$MissionFeedImpl implements _MissionFeed {
   @override
   final int missionPostId;
   @override
+  final int stepNum;
+  @override
   final String nickname;
   @override
   final String profileImage;
   @override
-  final DateTime date;
+  final String date;
   @override
   final String image;
   @override
@@ -238,7 +254,7 @@ class _$MissionFeedImpl implements _MissionFeed {
 
   @override
   String toString() {
-    return 'MissionFeed(missionPostId: $missionPostId, nickname: $nickname, profileImage: $profileImage, date: $date, image: $image, content: $content, likeCount: $likeCount, commentCount: $commentCount, isLiked: $isLiked)';
+    return 'MissionFeed(missionPostId: $missionPostId, stepNum: $stepNum, nickname: $nickname, profileImage: $profileImage, date: $date, image: $image, content: $content, likeCount: $likeCount, commentCount: $commentCount, isLiked: $isLiked)';
   }
 
   @override
@@ -248,6 +264,7 @@ class _$MissionFeedImpl implements _MissionFeed {
             other is _$MissionFeedImpl &&
             (identical(other.missionPostId, missionPostId) ||
                 other.missionPostId == missionPostId) &&
+            (identical(other.stepNum, stepNum) || other.stepNum == stepNum) &&
             (identical(other.nickname, nickname) ||
                 other.nickname == nickname) &&
             (identical(other.profileImage, profileImage) ||
@@ -264,7 +281,7 @@ class _$MissionFeedImpl implements _MissionFeed {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, missionPostId, nickname,
+  int get hashCode => Object.hash(runtimeType, missionPostId, stepNum, nickname,
       profileImage, date, image, content, likeCount, commentCount, isLiked);
 
   @JsonKey(ignore: true)
@@ -284,9 +301,10 @@ class _$MissionFeedImpl implements _MissionFeed {
 abstract class _MissionFeed implements MissionFeed {
   const factory _MissionFeed(
       {required final int missionPostId,
+      required final int stepNum,
       required final String nickname,
       required final String profileImage,
-      required final DateTime date,
+      required final String date,
       required final String image,
       required final String content,
       required final int likeCount,
@@ -299,11 +317,13 @@ abstract class _MissionFeed implements MissionFeed {
   @override
   int get missionPostId;
   @override
+  int get stepNum;
+  @override
   String get nickname;
   @override
   String get profileImage;
   @override
-  DateTime get date;
+  String get date;
   @override
   String get image;
   @override

--- a/lib/model/my_farmclub/mission_feed.g.dart
+++ b/lib/model/my_farmclub/mission_feed.g.dart
@@ -9,9 +9,10 @@ part of 'mission_feed.dart';
 _$MissionFeedImpl _$$MissionFeedImplFromJson(Map<String, dynamic> json) =>
     _$MissionFeedImpl(
       missionPostId: (json['missionPostId'] as num).toInt(),
+      stepNum: (json['stepNum'] as num).toInt(),
       nickname: json['nickname'] as String,
       profileImage: json['profileImage'] as String,
-      date: DateTime.parse(json['date'] as String),
+      date: json['date'] as String,
       image: json['image'] as String,
       content: json['content'] as String,
       likeCount: (json['likeCount'] as num).toInt(),
@@ -22,9 +23,10 @@ _$MissionFeedImpl _$$MissionFeedImplFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$$MissionFeedImplToJson(_$MissionFeedImpl instance) =>
     <String, dynamic>{
       'missionPostId': instance.missionPostId,
+      'stepNum': instance.stepNum,
       'nickname': instance.nickname,
       'profileImage': instance.profileImage,
-      'date': instance.date.toIso8601String(),
+      'date': instance.date,
       'image': instance.image,
       'content': instance.content,
       'likeCount': instance.likeCount,

--- a/lib/view/farmclub/component/farmclub_step.dart
+++ b/lib/view/farmclub/component/farmclub_step.dart
@@ -3,13 +3,12 @@ import 'package:farmus/common/farmus_picture_fix.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../common/content_empty.dart';
 import '../../../common/theme/farmus_theme_color.dart';
 import '../../../common/theme/farmus_theme_text_style.dart';
 import '../../../model/my_farmclub/my_farmclub_info_model.dart';
 import '../../mission_feed/mission_feed_screen.dart';
 import '../../mission_write/mission_write_screen.dart';
-
-import 'package:flutter/material.dart';
 
 class FarmclubStep extends ConsumerWidget {
   const FarmclubStep({
@@ -127,24 +126,28 @@ class FarmclubStep extends ConsumerWidget {
                     ],
                   ),
                   const SizedBox(height: 8),
-                  SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      mainAxisSize: MainAxisSize.min,
-                      children: step.images.isNotEmpty
-                          ? step.images.map((image) {
-                        return Padding(
-                          padding: const EdgeInsets.only(right: 8.0),
-                          child: FarmusPictureFix(
-                            size: 82,
-                            image: image,
+                  step.images.isNotEmpty
+                      ? SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: step.images.map((image) {
+                                return Padding(
+                                  padding: const EdgeInsets.only(right: 8.0),
+                                  child: FarmusPictureFix(
+                                    size: 82,
+                                    image: image,
+                                  ),
+                                );
+                              }).toList()),
+                        )
+                      : const SizedBox(
+                          width: double.infinity,
+                          child: ContentEmpty(
+                            text: '아직 미션을 완료한 파머가 없어요',
                           ),
-                        );
-                      }).toList()
-                          : [const SizedBox()],
-                    ),
-                  ),
+                        ),
                 ],
               ),
             ),

--- a/lib/view/home/component/home_farmclub_mission.dart
+++ b/lib/view/home/component/home_farmclub_mission.dart
@@ -2,6 +2,11 @@ import 'package:farmus/view/main/main_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../model/my_farmclub/my_farmclub_info_model.dart';
+import '../../../view_model/home/home_provider.dart';
+import '../../../view_model/my_farmclub/my_farmclub_info_notifier.dart';
+import '../../../view_model/my_vege/notifier/my_veggie_profile_notifier.dart';
+import '../../farmclub/component/farmclub_step.dart';
 import 'none/home_none_container.dart';
 
 class HomeFarmclubMission extends ConsumerWidget {
@@ -11,20 +16,44 @@ class HomeFarmclubMission extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return HomeNoneContainer(
-      title: '가입한 팜클럽이 없어요',
-      onPressed: () {
-        Navigator.pushAndRemoveUntil(
-          context,
-          MaterialPageRoute(
-            builder: (builder) => const MainScreen(
-              selectedIndex: 2,
+    final selectedVegeId = ref.watch(selectedVegeIdProvider);
+    var profile = ref.watch(myVeggieProfileProvider(selectedVegeId));
+
+    final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
+    final AsyncValue<MyFarmclubInfoModel> myFarmclubInfo =
+        ref.watch(myFarmclubInfoModelProvider(selectedFarmclubId));
+
+    return profile.when(
+      data: (profileInfo) => profileInfo.step == -1
+          ? HomeNoneContainer(
+              title: '가입한 팜클럽이 없어요',
+              onPressed: () {
+                Navigator.pushAndRemoveUntil(
+                  context,
+                  MaterialPageRoute(
+                    builder: (builder) => const MainScreen(
+                      selectedIndex: 2,
+                    ),
+                  ),
+                  (route) => false,
+                );
+              },
+              buttonText: '팜클럽 가입하기',
+            )
+          : myFarmclubInfo.when(
+              data: (farmclubInfo) => FarmclubStep(
+                wholeMember: farmclubInfo.wholeMemberCount,
+                step: farmclubInfo.steps[farmclubInfo.currentStep - 1],
+                farmclubInfo: farmclubInfo,
+                isButton: true,
+              ),
+              error: (error, stack) =>
+                  Center(child: Text('Error: ${error.toString()}')),
+              loading: () => Container(),
             ),
-          ),
-          (route) => false,
-        );
-      },
-      buttonText: '팜클럽 가입하기',
+      error: (error, stack) =>
+          Center(child: Text('Error: ${error.toString()}')),
+      loading: () => Container(),
     );
   }
 }

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -24,7 +24,6 @@ class MissionFeedTabBar extends ConsumerWidget {
 
     List<Widget> tabViews = [];
 
-    // 전체 탭에 missionFeed 데이터를 추가
     tabViews.add(
       missionFeed.when(
         data: (feeds) => SingleChildScrollView(
@@ -72,21 +71,42 @@ class MissionFeedTabBar extends ConsumerWidget {
       ),
     );
 
-    // farmclubInfo.steps 추가
     for (var step in farmclubInfo.steps) {
       tabViews.add(
-        SingleChildScrollView(
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              children: [
-                MissionStepInfo(
-                  step: step,
-                  isButton: true,
+        missionFeed.when(
+          data: (feeds) {
+            final stepFeeds =
+                feeds.where((feed) => feed.stepNum == step.stepNum).toList();
+
+            return SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  children: [
+                    MissionStepInfo(
+                      step: step,
+                      isButton: true,
+                    ),
+                    const SizedBox(height: 16.0),
+                    ...stepFeeds.map((feed) {
+                      return FarmusFeed(
+                          feedId: feed.missionPostId,
+                          profileImage: feed.profileImage,
+                          nickname: feed.nickname,
+                          writeDateTime: feed.date,
+                          content: feed.content,
+                          image: feed.image,
+                          commentCount: feed.commentCount,
+                          likeCount: feed.likeCount,
+                          myLike: feed.isLiked);
+                    }),
+                  ],
                 ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (err, stack) => Center(child: Text('Error: $err')),
         ),
       );
     }

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -1,3 +1,4 @@
+import 'package:farmus/common/content_empty.dart';
 import 'package:farmus/common/farmus_feed.dart';
 import 'package:farmus/model/my_farmclub/mission_feed.dart';
 import 'package:farmus/view_model/my_farmclub/mission_feed_notifier.dart';
@@ -49,18 +50,28 @@ class MissionFeedTabBar extends ConsumerWidget {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: Column(
-                  children: feeds.map((feed) {
-                    return FarmusFeed(
-                        feedId: feed.missionPostId,
-                        profileImage: feed.profileImage,
-                        nickname: feed.nickname,
-                        writeDateTime: feed.date,
-                        content: feed.content,
-                        image: feed.image,
-                        commentCount: feed.commentCount,
-                        likeCount: feed.likeCount,
-                        myLike: feed.isLiked);
-                  }).toList(),
+                  children: feeds.isEmpty
+                      ? const [
+                          SizedBox(
+                            width: double.infinity,
+                            child: ContentEmpty(
+                              text: '아직 미션을 완료한 파머가 없어요',
+                              padding: 48.0,
+                            ),
+                          )
+                        ]
+                      : feeds.map((feed) {
+                          return FarmusFeed(
+                              feedId: feed.missionPostId,
+                              profileImage: feed.profileImage,
+                              nickname: feed.nickname,
+                              writeDateTime: feed.date,
+                              content: feed.content,
+                              image: feed.image,
+                              commentCount: feed.commentCount,
+                              likeCount: feed.likeCount,
+                              myLike: feed.isLiked);
+                        }).toList(),
                 ),
               ),
             ],
@@ -88,18 +99,28 @@ class MissionFeedTabBar extends ConsumerWidget {
                       isButton: true,
                     ),
                     const SizedBox(height: 16.0),
-                    ...stepFeeds.map((feed) {
-                      return FarmusFeed(
-                          feedId: feed.missionPostId,
-                          profileImage: feed.profileImage,
-                          nickname: feed.nickname,
-                          writeDateTime: feed.date,
-                          content: feed.content,
-                          image: feed.image,
-                          commentCount: feed.commentCount,
-                          likeCount: feed.likeCount,
-                          myLike: feed.isLiked);
-                    }),
+                    stepFeeds.isEmpty
+                        ? const SizedBox(
+                            width: double.infinity,
+                            child: ContentEmpty(
+                              text: '아직 미션을 완료한 파머가 없어요',
+                              padding: 48.0,
+                            ),
+                          )
+                        : Column(
+                            children: stepFeeds.map((feed) {
+                              return FarmusFeed(
+                                  feedId: feed.missionPostId,
+                                  profileImage: feed.profileImage,
+                                  nickname: feed.nickname,
+                                  writeDateTime: feed.date,
+                                  content: feed.content,
+                                  image: feed.image,
+                                  commentCount: feed.commentCount,
+                                  likeCount: feed.likeCount,
+                                  myLike: feed.isLiked);
+                            }).toList(),
+                          ),
                   ],
                 ),
               ),

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -30,13 +30,12 @@ class MissionFeedTabBar extends ConsumerWidget {
         data: (feeds) => SingleChildScrollView(
           child: Column(
             children: [
-              Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8.0, vertical: 16.0),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 16.0),
                 child: SingleChildScrollView(
                   scrollDirection: Axis.horizontal,
                   child: Row(
-                    children: const [
+                    children: [
                       MissionFeedSelectProfile(),
                       MissionFeedBasicProfile(nickname: '감자'),
                       MissionFeedBasicProfile(nickname: '홈프로텍터'),
@@ -56,7 +55,7 @@ class MissionFeedTabBar extends ConsumerWidget {
                         feedId: feed.missionPostId,
                         profileImage: feed.profileImage,
                         nickname: feed.nickname,
-                        writeDateTime: feed.date.toIso8601String(),
+                        writeDateTime: feed.date,
                         content: feed.content,
                         image: feed.image,
                         commentCount: feed.commentCount,

--- a/lib/view_model/my_farmclub/mission_feed_notifier.g.dart
+++ b/lib/view_model/my_farmclub/mission_feed_notifier.g.dart
@@ -6,7 +6,7 @@ part of 'mission_feed_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$missionFeedHash() => r'44b56dd5b2ba27ca61d921f805ca42f3d7d8f0f4';
+String _$missionFeedHash() => r'9e9c549574fcb3f7ec69e07ae23161f612f4ae14';
 
 /// Copied from Dart SDK
 class _SystemHash {


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #265 


### 🍠 Summary
- Step 별 조회
- 완료한 Step 없을 경우
- 홈에서 현재 Step 띄우기

https://github.com/user-attachments/assets/18a65938-0dcc-4c91-b08e-1aea6e394b53




### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
팜클럽 현재 미션을 조회할 때 팜클럽 아이디로 조회하는데,
홈에서는 선택된 팜클럽 아이디를 모르는 상태고 채소 아이디만 주고 있습니다...
그래서 현재 선택된 채소와 팜클럽 미션 조회의 매치가 안될 수 밖에 없어서
내일 회의때 서버, 기디와 의논해봐야 할 것 같아요

