### PR TITLE
[Feat] 미션 인증 목록 조회(유저) API 연동

### DIFF
--- a/lib/common/tab_bar/farmclub_tab_bar.dart
+++ b/lib/common/tab_bar/farmclub_tab_bar.dart
@@ -18,7 +18,7 @@ class FarmclubTabBar extends StatelessWidget {
     final List<StepModel> currentSteps = [steps[currentStepIndex]];
 
     final List<StepModel> previousSteps =
-        (currentStepIndex > 0) ? steps.sublist(0, currentStepIndex - 1) : [];
+        (currentStepIndex > 0) ? steps.sublist(0, currentStepIndex) : [];
     final List<StepModel> nextSteps = (currentStepIndex < steps.length - 1)
         ? steps.sublist(currentStepIndex + 1)
         : [];

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -76,7 +76,6 @@ class MyFarmclubService {
     final response = await apiClient.delete(url, body: body);
 
     if (response.statusCode == 200) {
-      print(utf8.decode(response.bodyBytes));
       return utf8.decode(response.bodyBytes);
     } else {
       throw Exception('팜클럽 탈퇴 실패');
@@ -84,11 +83,11 @@ class MyFarmclubService {
   }
 
   Future<String> myMissionComplete(
-      File file,
-      String content,
-      int farmClubId,
-      BuildContext context,
-      ) async {
+    File file,
+    String content,
+    int farmClubId,
+    BuildContext context,
+  ) async {
     const url = '/api/farm-club/mission';
 
     final jsonBody = {
@@ -107,7 +106,8 @@ class MyFarmclubService {
     );
 
     if (response.statusCode == 200) {
-      final Map<String, dynamic> responseData = jsonDecode(utf8.decode(response.bodyBytes));
+      final Map<String, dynamic> responseData =
+          jsonDecode(utf8.decode(response.bodyBytes));
 
       if (responseData['data']['isLastStep'] == true) {
         try {
@@ -130,8 +130,7 @@ class MyFarmclubService {
     }
   }
 
-  Future<String> myMissionSuccess(
-      int farmClubId) async {
+  Future<String> myMissionSuccess(int farmClubId) async {
     final url = '/api/farm-club/$farmClubId/success';
 
     final body = jsonEncode({
@@ -146,6 +145,7 @@ class MyFarmclubService {
       throw Exception('팜클럽 성공 실패');
     }
   }
+
   Future<String> missionCommentAdd(int missionPostId, String content) async {
     const url = '/api/farm-club/mission/comment';
 
@@ -163,6 +163,7 @@ class MyFarmclubService {
       throw Exception('미션 댓글 추가 실패');
     }
   }
+
   Future<String> missionComment(int missionPostId) async {
     final url = '/api/farm-club/mission/$missionPostId';
 
@@ -178,7 +179,6 @@ class MyFarmclubService {
   Future<String> missionLike(int missionPostId) async {
     final url = '/api/farm-club/mission/like/$missionPostId';
 
-
     final response = await apiClient.post(url);
 
     if (response.statusCode == 200) {
@@ -191,17 +191,17 @@ class MyFarmclubService {
   Future<String> missionLikeDelete(int missionPostId) async {
     final url = '/api/farm-club/mission/like/$missionPostId';
 
-
     final response = await apiClient.delete(url);
 
     if (response.statusCode == 200) {
-      print(utf8.decode(response.bodyBytes));
-
       return utf8.decode(response.bodyBytes);
     } else {
-      print(utf8.decode(response.bodyBytes));
-
       throw Exception('미션 좋아요 삭제 실패');
     }
+  }
+
+  Future<String> farmclubUserList(int farmClubId) async {
+    final url = '/api/farm-club/$farmClubId/user';
+    return _fetchData(url, '팜 클럽 유저 불러오기 실패');
   }
 }

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -202,6 +202,6 @@ class MyFarmclubService {
 
   Future<String> farmclubUserList(int farmClubId) async {
     final url = '/api/farm-club/$farmClubId/user';
-    return _fetchData(url, '팜 클럽 유저 불러오기 실패');
+    return _fetchData(url, '팜클럽 유저 불러오기 실패');
   }
 }

--- a/lib/model/mission/mission_user_list_model.dart
+++ b/lib/model/mission/mission_user_list_model.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'mission_user_list_model.freezed.dart';
+part 'mission_user_list_model.g.dart';
+
+@freezed
+class MissionUserListModel with _$MissionUserListModel {
+  const factory MissionUserListModel({
+    required String nickname,
+    required String profileImage,
+  }) = _MissionUserListModelt;
+
+  factory MissionUserListModel.fromJson(Map<String, dynamic> json) =>
+      _$MissionUserListModelFromJson(json);
+}

--- a/lib/model/mission/mission_user_list_model.dart
+++ b/lib/model/mission/mission_user_list_model.dart
@@ -6,9 +6,10 @@ part 'mission_user_list_model.g.dart';
 @freezed
 class MissionUserListModel with _$MissionUserListModel {
   const factory MissionUserListModel({
+    required int userId,
     required String nickname,
     required String profileImage,
-  }) = _MissionUserListModelt;
+  }) = _MissionUserListModel;
 
   factory MissionUserListModel.fromJson(Map<String, dynamic> json) =>
       _$MissionUserListModelFromJson(json);

--- a/lib/model/mission/mission_user_list_model.freezed.dart
+++ b/lib/model/mission/mission_user_list_model.freezed.dart
@@ -15,11 +15,12 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 MissionUserListModel _$MissionUserListModelFromJson(Map<String, dynamic> json) {
-  return _MissionUserListModelt.fromJson(json);
+  return _MissionUserListModel.fromJson(json);
 }
 
 /// @nodoc
 mixin _$MissionUserListModel {
+  int get userId => throw _privateConstructorUsedError;
   String get nickname => throw _privateConstructorUsedError;
   String get profileImage => throw _privateConstructorUsedError;
 
@@ -35,7 +36,7 @@ abstract class $MissionUserListModelCopyWith<$Res> {
           $Res Function(MissionUserListModel) then) =
       _$MissionUserListModelCopyWithImpl<$Res, MissionUserListModel>;
   @useResult
-  $Res call({String nickname, String profileImage});
+  $Res call({int userId, String nickname, String profileImage});
 }
 
 /// @nodoc
@@ -52,10 +53,15 @@ class _$MissionUserListModelCopyWithImpl<$Res,
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? userId = null,
     Object? nickname = null,
     Object? profileImage = null,
   }) {
     return _then(_value.copyWith(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
       nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
@@ -69,33 +75,36 @@ class _$MissionUserListModelCopyWithImpl<$Res,
 }
 
 /// @nodoc
-abstract class _$$MissionUserListModeltImplCopyWith<$Res>
+abstract class _$$MissionUserListModelImplCopyWith<$Res>
     implements $MissionUserListModelCopyWith<$Res> {
-  factory _$$MissionUserListModeltImplCopyWith(
-          _$MissionUserListModeltImpl value,
-          $Res Function(_$MissionUserListModeltImpl) then) =
-      __$$MissionUserListModeltImplCopyWithImpl<$Res>;
+  factory _$$MissionUserListModelImplCopyWith(_$MissionUserListModelImpl value,
+          $Res Function(_$MissionUserListModelImpl) then) =
+      __$$MissionUserListModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String nickname, String profileImage});
+  $Res call({int userId, String nickname, String profileImage});
 }
 
 /// @nodoc
-class __$$MissionUserListModeltImplCopyWithImpl<$Res>
-    extends _$MissionUserListModelCopyWithImpl<$Res,
-        _$MissionUserListModeltImpl>
-    implements _$$MissionUserListModeltImplCopyWith<$Res> {
-  __$$MissionUserListModeltImplCopyWithImpl(_$MissionUserListModeltImpl _value,
-      $Res Function(_$MissionUserListModeltImpl) _then)
+class __$$MissionUserListModelImplCopyWithImpl<$Res>
+    extends _$MissionUserListModelCopyWithImpl<$Res, _$MissionUserListModelImpl>
+    implements _$$MissionUserListModelImplCopyWith<$Res> {
+  __$$MissionUserListModelImplCopyWithImpl(_$MissionUserListModelImpl _value,
+      $Res Function(_$MissionUserListModelImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
   @override
   $Res call({
+    Object? userId = null,
     Object? nickname = null,
     Object? profileImage = null,
   }) {
-    return _then(_$MissionUserListModeltImpl(
+    return _then(_$MissionUserListModelImpl(
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as int,
       nickname: null == nickname
           ? _value.nickname
           : nickname // ignore: cast_nullable_to_non_nullable
@@ -110,13 +119,17 @@ class __$$MissionUserListModeltImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$MissionUserListModeltImpl implements _MissionUserListModelt {
-  const _$MissionUserListModeltImpl(
-      {required this.nickname, required this.profileImage});
+class _$MissionUserListModelImpl implements _MissionUserListModel {
+  const _$MissionUserListModelImpl(
+      {required this.userId,
+      required this.nickname,
+      required this.profileImage});
 
-  factory _$MissionUserListModeltImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MissionUserListModeltImplFromJson(json);
+  factory _$MissionUserListModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MissionUserListModelImplFromJson(json);
 
+  @override
+  final int userId;
   @override
   final String nickname;
   @override
@@ -124,14 +137,15 @@ class _$MissionUserListModeltImpl implements _MissionUserListModelt {
 
   @override
   String toString() {
-    return 'MissionUserListModel(nickname: $nickname, profileImage: $profileImage)';
+    return 'MissionUserListModel(userId: $userId, nickname: $nickname, profileImage: $profileImage)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$MissionUserListModeltImpl &&
+            other is _$MissionUserListModelImpl &&
+            (identical(other.userId, userId) || other.userId == userId) &&
             (identical(other.nickname, nickname) ||
                 other.nickname == nickname) &&
             (identical(other.profileImage, profileImage) ||
@@ -140,37 +154,41 @@ class _$MissionUserListModeltImpl implements _MissionUserListModelt {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, nickname, profileImage);
+  int get hashCode => Object.hash(runtimeType, userId, nickname, profileImage);
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$MissionUserListModeltImplCopyWith<_$MissionUserListModeltImpl>
-      get copyWith => __$$MissionUserListModeltImplCopyWithImpl<
-          _$MissionUserListModeltImpl>(this, _$identity);
+  _$$MissionUserListModelImplCopyWith<_$MissionUserListModelImpl>
+      get copyWith =>
+          __$$MissionUserListModelImplCopyWithImpl<_$MissionUserListModelImpl>(
+              this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$MissionUserListModeltImplToJson(
+    return _$$MissionUserListModelImplToJson(
       this,
     );
   }
 }
 
-abstract class _MissionUserListModelt implements MissionUserListModel {
-  const factory _MissionUserListModelt(
-      {required final String nickname,
-      required final String profileImage}) = _$MissionUserListModeltImpl;
+abstract class _MissionUserListModel implements MissionUserListModel {
+  const factory _MissionUserListModel(
+      {required final int userId,
+      required final String nickname,
+      required final String profileImage}) = _$MissionUserListModelImpl;
 
-  factory _MissionUserListModelt.fromJson(Map<String, dynamic> json) =
-      _$MissionUserListModeltImpl.fromJson;
+  factory _MissionUserListModel.fromJson(Map<String, dynamic> json) =
+      _$MissionUserListModelImpl.fromJson;
 
+  @override
+  int get userId;
   @override
   String get nickname;
   @override
   String get profileImage;
   @override
   @JsonKey(ignore: true)
-  _$$MissionUserListModeltImplCopyWith<_$MissionUserListModeltImpl>
+  _$$MissionUserListModelImplCopyWith<_$MissionUserListModelImpl>
       get copyWith => throw _privateConstructorUsedError;
 }

--- a/lib/model/mission/mission_user_list_model.freezed.dart
+++ b/lib/model/mission/mission_user_list_model.freezed.dart
@@ -1,0 +1,176 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mission_user_list_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+MissionUserListModel _$MissionUserListModelFromJson(Map<String, dynamic> json) {
+  return _MissionUserListModelt.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MissionUserListModel {
+  String get nickname => throw _privateConstructorUsedError;
+  String get profileImage => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MissionUserListModelCopyWith<MissionUserListModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MissionUserListModelCopyWith<$Res> {
+  factory $MissionUserListModelCopyWith(MissionUserListModel value,
+          $Res Function(MissionUserListModel) then) =
+      _$MissionUserListModelCopyWithImpl<$Res, MissionUserListModel>;
+  @useResult
+  $Res call({String nickname, String profileImage});
+}
+
+/// @nodoc
+class _$MissionUserListModelCopyWithImpl<$Res,
+        $Val extends MissionUserListModel>
+    implements $MissionUserListModelCopyWith<$Res> {
+  _$MissionUserListModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? nickname = null,
+    Object? profileImage = null,
+  }) {
+    return _then(_value.copyWith(
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileImage: null == profileImage
+          ? _value.profileImage
+          : profileImage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MissionUserListModeltImplCopyWith<$Res>
+    implements $MissionUserListModelCopyWith<$Res> {
+  factory _$$MissionUserListModeltImplCopyWith(
+          _$MissionUserListModeltImpl value,
+          $Res Function(_$MissionUserListModeltImpl) then) =
+      __$$MissionUserListModeltImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String nickname, String profileImage});
+}
+
+/// @nodoc
+class __$$MissionUserListModeltImplCopyWithImpl<$Res>
+    extends _$MissionUserListModelCopyWithImpl<$Res,
+        _$MissionUserListModeltImpl>
+    implements _$$MissionUserListModeltImplCopyWith<$Res> {
+  __$$MissionUserListModeltImplCopyWithImpl(_$MissionUserListModeltImpl _value,
+      $Res Function(_$MissionUserListModeltImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? nickname = null,
+    Object? profileImage = null,
+  }) {
+    return _then(_$MissionUserListModeltImpl(
+      nickname: null == nickname
+          ? _value.nickname
+          : nickname // ignore: cast_nullable_to_non_nullable
+              as String,
+      profileImage: null == profileImage
+          ? _value.profileImage
+          : profileImage // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MissionUserListModeltImpl implements _MissionUserListModelt {
+  const _$MissionUserListModeltImpl(
+      {required this.nickname, required this.profileImage});
+
+  factory _$MissionUserListModeltImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MissionUserListModeltImplFromJson(json);
+
+  @override
+  final String nickname;
+  @override
+  final String profileImage;
+
+  @override
+  String toString() {
+    return 'MissionUserListModel(nickname: $nickname, profileImage: $profileImage)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MissionUserListModeltImpl &&
+            (identical(other.nickname, nickname) ||
+                other.nickname == nickname) &&
+            (identical(other.profileImage, profileImage) ||
+                other.profileImage == profileImage));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, nickname, profileImage);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MissionUserListModeltImplCopyWith<_$MissionUserListModeltImpl>
+      get copyWith => __$$MissionUserListModeltImplCopyWithImpl<
+          _$MissionUserListModeltImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MissionUserListModeltImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MissionUserListModelt implements MissionUserListModel {
+  const factory _MissionUserListModelt(
+      {required final String nickname,
+      required final String profileImage}) = _$MissionUserListModeltImpl;
+
+  factory _MissionUserListModelt.fromJson(Map<String, dynamic> json) =
+      _$MissionUserListModeltImpl.fromJson;
+
+  @override
+  String get nickname;
+  @override
+  String get profileImage;
+  @override
+  @JsonKey(ignore: true)
+  _$$MissionUserListModeltImplCopyWith<_$MissionUserListModeltImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/model/mission/mission_user_list_model.g.dart
+++ b/lib/model/mission/mission_user_list_model.g.dart
@@ -6,16 +6,18 @@ part of 'mission_user_list_model.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$MissionUserListModeltImpl _$$MissionUserListModeltImplFromJson(
+_$MissionUserListModelImpl _$$MissionUserListModelImplFromJson(
         Map<String, dynamic> json) =>
-    _$MissionUserListModeltImpl(
+    _$MissionUserListModelImpl(
+      userId: (json['userId'] as num).toInt(),
       nickname: json['nickname'] as String,
       profileImage: json['profileImage'] as String,
     );
 
-Map<String, dynamic> _$$MissionUserListModeltImplToJson(
-        _$MissionUserListModeltImpl instance) =>
+Map<String, dynamic> _$$MissionUserListModelImplToJson(
+        _$MissionUserListModelImpl instance) =>
     <String, dynamic>{
+      'userId': instance.userId,
       'nickname': instance.nickname,
       'profileImage': instance.profileImage,
     };

--- a/lib/model/mission/mission_user_list_model.g.dart
+++ b/lib/model/mission/mission_user_list_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_user_list_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$MissionUserListModeltImpl _$$MissionUserListModeltImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MissionUserListModeltImpl(
+      nickname: json['nickname'] as String,
+      profileImage: json['profileImage'] as String,
+    );
+
+Map<String, dynamic> _$$MissionUserListModeltImplToJson(
+        _$MissionUserListModeltImpl instance) =>
+    <String, dynamic>{
+      'nickname': instance.nickname,
+      'profileImage': instance.profileImage,
+    };

--- a/lib/model/my_farmclub/mission_feed.dart
+++ b/lib/model/my_farmclub/mission_feed.dart
@@ -7,6 +7,7 @@ part 'mission_feed.g.dart';
 class MissionFeed with _$MissionFeed {
   const factory MissionFeed({
     required int missionPostId,
+    required int userId,
     required int stepNum,
     required String nickname,
     required String profileImage,

--- a/lib/model/my_farmclub/mission_feed.freezed.dart
+++ b/lib/model/my_farmclub/mission_feed.freezed.dart
@@ -21,6 +21,7 @@ MissionFeed _$MissionFeedFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$MissionFeed {
   int get missionPostId => throw _privateConstructorUsedError;
+  int get userId => throw _privateConstructorUsedError;
   int get stepNum => throw _privateConstructorUsedError;
   String get nickname => throw _privateConstructorUsedError;
   String get profileImage => throw _privateConstructorUsedError;
@@ -45,6 +46,7 @@ abstract class $MissionFeedCopyWith<$Res> {
   @useResult
   $Res call(
       {int missionPostId,
+      int userId,
       int stepNum,
       String nickname,
       String profileImage,
@@ -70,6 +72,7 @@ class _$MissionFeedCopyWithImpl<$Res, $Val extends MissionFeed>
   @override
   $Res call({
     Object? missionPostId = null,
+    Object? userId = null,
     Object? stepNum = null,
     Object? nickname = null,
     Object? profileImage = null,
@@ -84,6 +87,10 @@ class _$MissionFeedCopyWithImpl<$Res, $Val extends MissionFeed>
       missionPostId: null == missionPostId
           ? _value.missionPostId
           : missionPostId // ignore: cast_nullable_to_non_nullable
+              as int,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
               as int,
       stepNum: null == stepNum
           ? _value.stepNum
@@ -135,6 +142,7 @@ abstract class _$$MissionFeedImplCopyWith<$Res>
   @useResult
   $Res call(
       {int missionPostId,
+      int userId,
       int stepNum,
       String nickname,
       String profileImage,
@@ -158,6 +166,7 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? missionPostId = null,
+    Object? userId = null,
     Object? stepNum = null,
     Object? nickname = null,
     Object? profileImage = null,
@@ -172,6 +181,10 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
       missionPostId: null == missionPostId
           ? _value.missionPostId
           : missionPostId // ignore: cast_nullable_to_non_nullable
+              as int,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
               as int,
       stepNum: null == stepNum
           ? _value.stepNum
@@ -218,6 +231,7 @@ class __$$MissionFeedImplCopyWithImpl<$Res>
 class _$MissionFeedImpl implements _MissionFeed {
   const _$MissionFeedImpl(
       {required this.missionPostId,
+      required this.userId,
       required this.stepNum,
       required this.nickname,
       required this.profileImage,
@@ -233,6 +247,8 @@ class _$MissionFeedImpl implements _MissionFeed {
 
   @override
   final int missionPostId;
+  @override
+  final int userId;
   @override
   final int stepNum;
   @override
@@ -254,7 +270,7 @@ class _$MissionFeedImpl implements _MissionFeed {
 
   @override
   String toString() {
-    return 'MissionFeed(missionPostId: $missionPostId, stepNum: $stepNum, nickname: $nickname, profileImage: $profileImage, date: $date, image: $image, content: $content, likeCount: $likeCount, commentCount: $commentCount, isLiked: $isLiked)';
+    return 'MissionFeed(missionPostId: $missionPostId, userId: $userId, stepNum: $stepNum, nickname: $nickname, profileImage: $profileImage, date: $date, image: $image, content: $content, likeCount: $likeCount, commentCount: $commentCount, isLiked: $isLiked)';
   }
 
   @override
@@ -264,6 +280,7 @@ class _$MissionFeedImpl implements _MissionFeed {
             other is _$MissionFeedImpl &&
             (identical(other.missionPostId, missionPostId) ||
                 other.missionPostId == missionPostId) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
             (identical(other.stepNum, stepNum) || other.stepNum == stepNum) &&
             (identical(other.nickname, nickname) ||
                 other.nickname == nickname) &&
@@ -281,8 +298,19 @@ class _$MissionFeedImpl implements _MissionFeed {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, missionPostId, stepNum, nickname,
-      profileImage, date, image, content, likeCount, commentCount, isLiked);
+  int get hashCode => Object.hash(
+      runtimeType,
+      missionPostId,
+      userId,
+      stepNum,
+      nickname,
+      profileImage,
+      date,
+      image,
+      content,
+      likeCount,
+      commentCount,
+      isLiked);
 
   @JsonKey(ignore: true)
   @override
@@ -301,6 +329,7 @@ class _$MissionFeedImpl implements _MissionFeed {
 abstract class _MissionFeed implements MissionFeed {
   const factory _MissionFeed(
       {required final int missionPostId,
+      required final int userId,
       required final int stepNum,
       required final String nickname,
       required final String profileImage,
@@ -316,6 +345,8 @@ abstract class _MissionFeed implements MissionFeed {
 
   @override
   int get missionPostId;
+  @override
+  int get userId;
   @override
   int get stepNum;
   @override

--- a/lib/model/my_farmclub/mission_feed.g.dart
+++ b/lib/model/my_farmclub/mission_feed.g.dart
@@ -9,6 +9,7 @@ part of 'mission_feed.dart';
 _$MissionFeedImpl _$$MissionFeedImplFromJson(Map<String, dynamic> json) =>
     _$MissionFeedImpl(
       missionPostId: (json['missionPostId'] as num).toInt(),
+      userId: (json['userId'] as num).toInt(),
       stepNum: (json['stepNum'] as num).toInt(),
       nickname: json['nickname'] as String,
       profileImage: json['profileImage'] as String,
@@ -23,6 +24,7 @@ _$MissionFeedImpl _$$MissionFeedImplFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$$MissionFeedImplToJson(_$MissionFeedImpl instance) =>
     <String, dynamic>{
       'missionPostId': instance.missionPostId,
+      'userId': instance.userId,
       'stepNum': instance.stepNum,
       'nickname': instance.nickname,
       'profileImage': instance.profileImage,

--- a/lib/repository/my_farmclub_repository.dart
+++ b/lib/repository/my_farmclub_repository.dart
@@ -76,4 +76,9 @@ class MyFarmclubRepository {
     String? response = await MyFarmclubService().myMissionSuccess(farmClubId);
     return response;
   }
+
+  static Future<String> farmclubUserList(int farmClubId) async {
+    String? response = await MyFarmclubService().farmclubUserList(farmClubId);
+    return response;
+  }
 }

--- a/lib/view/farmclub/component/farmclub_profile.dart
+++ b/lib/view/farmclub/component/farmclub_profile.dart
@@ -25,6 +25,7 @@ class FarmclubProfile extends ConsumerWidget {
               FarmclubSelectProfile(
                 image: farmclubInfoModel!.farmClubImage,
                 size: 64,
+                isSelected: true,
               ),
               SvgPicture.asset('assets/image/ic_farmclub_mark.svg'),
             ],

--- a/lib/view/farmclub/component/farmclub_select_profile.dart
+++ b/lib/view/farmclub/component/farmclub_select_profile.dart
@@ -6,25 +6,31 @@ import '../../../common/theme/farmus_theme_color.dart';
 class FarmclubSelectProfile extends ConsumerWidget {
   final String image;
   final double size;
+  final bool isSelected;
 
-  const FarmclubSelectProfile(
-      {super.key, required this.image, required this.size});
+  const FarmclubSelectProfile({
+    super.key,
+    required this.image,
+    required this.size,
+    this.isSelected = false,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Stack(
       alignment: Alignment.center,
       children: [
-        Container(
-          width: size,
-          height: size,
-          decoration: const BoxDecoration(
-            shape: BoxShape.circle,
+        if (isSelected)
+          Container(
+            width: size,
+            height: size,
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+            ),
+            child: Image.asset(
+              'assets/image/image_farmclub_profile_background.png',
+            ),
           ),
-          child: Image.asset(
-            'assets/image/image_farmclub_profile_background.png',
-          ),
-        ),
         Container(
           width: 56,
           height: 56,

--- a/lib/view/mission_feed/component/mission_feed_select_profile.dart
+++ b/lib/view/mission_feed/component/mission_feed_select_profile.dart
@@ -1,52 +1,34 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_svg/flutter_svg.dart';
 
 import '../../../common/theme/farmus_theme_text_style.dart';
-import '../../../model/my_farmclub/my_farmclub_info_model.dart';
-import '../../../model/my_farmclub/my_farmclub_model.dart';
-import '../../../view_model/home/home_provider.dart';
-import '../../../view_model/my_farmclub/my_farmclub_info_notifier.dart';
-import '../../../view_model/my_farmclub/my_farmclub_notifier.dart';
-import '../../../view_model/on_boarding/on_boarding_finish_notifier.dart';
+import '../../../model/mission/mission_user_list_model.dart';
 import '../../farmclub/component/farmclub_select_profile.dart';
 
 class MissionFeedSelectProfile extends ConsumerWidget {
-  const MissionFeedSelectProfile({super.key});
+  final MissionUserListModel user;
+  final bool isSelected;
+
+  const MissionFeedSelectProfile({super.key, required this.user, required this.isSelected});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<List<MyFarmclubModel>> myFarmclub =
-        ref.watch(myFarmclubModelProvider);
-    final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
-    final AsyncValue<MyFarmclubInfoModel> myFarmclubInfo = ref.watch(
-        myFarmclubInfoModelProvider(
-            selectedFarmclubId ?? myFarmclub.value?.first.farmClubId));
-    final nickName = ref.watch(onBoardingFinishNotifierProvider);
-
     return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-        child: myFarmclubInfo.when(
-          data: (farmclubInfo) {
-            return Column(
-              children: [
-                FarmclubSelectProfile(
-                  image: farmclubInfo.farmClubImage,
-                  size: 64,
-                ),
-                const SizedBox(
-                  height: 8.0,
-                ),
-                Text(
-                  '${nickName.value}',
-                  style: FarmusThemeTextStyle.gray1Medium11,
-                ),
-              ],
-            );
-          },
-          loading: () => const CircularProgressIndicator(),
-          error: (error, stack) =>
-              SvgPicture.asset('assets/image/ic_alert_circle.svg'),
-        ));
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: Column(
+        children: [
+          FarmclubSelectProfile(
+            image: user.profileImage,
+            size: 64,
+            isSelected : isSelected
+          ),
+          const SizedBox(height: 8.0),
+          Text(
+            user.nickname,
+            style: FarmusThemeTextStyle.gray1Medium11,
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -6,62 +6,121 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../common/tab_bar/primary_tab_bar.dart';
+import '../../../model/mission/mission_user_list_model.dart';
 import '../../../model/my_farmclub/my_farmclub_info_model.dart';
 import '../../../view_model/home/home_provider.dart';
+import '../../../view_model/mission_feed/mission_user_list_model_notifier.dart';
+import '../../../view_model/on_boarding/on_boarding_finish_notifier.dart';
 import '../../mission_write/component/mission_step_info.dart';
-import 'mission_feed_basic_profile.dart';
 import 'mission_feed_select_profile.dart';
 
-class MissionFeedTabBar extends ConsumerWidget {
+class MissionFeedTabBar extends ConsumerStatefulWidget {
   const MissionFeedTabBar({super.key, required this.farmclubInfo});
 
   final MyFarmclubInfoModel farmclubInfo;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  _MissionFeedTabBarState createState() => _MissionFeedTabBarState();
+}
+
+class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
+  String? selectedUserNickname;
+
+  @override
+  Widget build(BuildContext context) {
     final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
     final AsyncValue<List<MissionFeed>> missionFeed =
         ref.watch(missionFeedProvider(selectedFarmclubId));
 
+    final AsyncValue<List<MissionUserListModel>> missionUserList =
+        ref.watch(missionUserListModelProvider(selectedFarmclubId));
+
+    final nickName = ref.watch(onBoardingFinishNotifierProvider);
     List<Widget> tabViews = [];
 
     tabViews.add(
       missionFeed.when(
-        data: (feeds) => SingleChildScrollView(
-          child: Column(
-            children: [
-              const Padding(
-                padding: EdgeInsets.symmetric(horizontal: 8.0, vertical: 16.0),
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: Row(
-                    children: [
-                      MissionFeedSelectProfile(),
-                      MissionFeedBasicProfile(nickname: '감자'),
-                      MissionFeedBasicProfile(nickname: '홈프로텍터'),
-                      MissionFeedBasicProfile(nickname: '갓팜'),
-                      MissionFeedBasicProfile(nickname: '푸우'),
-                      MissionFeedBasicProfile(nickname: '종강언제함'),
-                      MissionFeedBasicProfile(nickname: '배고파'),
-                    ],
+        data: (feeds) {
+          List<MissionFeed> filteredFeeds = selectedUserNickname != null
+              ? feeds
+                  .where((feed) => feed.nickname == selectedUserNickname)
+                  .toList()
+              : feeds;
+
+          return SingleChildScrollView(
+            child: Column(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 8.0, vertical: 16.0),
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: [
+                        missionUserList.when(
+                          data: (users) {
+                            final myAccount = users.firstWhere(
+                              (user) => user.nickname == nickName.value,
+                            );
+                            final otherUsers = users
+                                .where(
+                                    (user) => user.nickname != nickName.value)
+                                .toList();
+
+                            List<MissionUserListModel> sortedUsers = [];
+                            if (myAccount != null) {
+                              sortedUsers = [myAccount, ...otherUsers];
+                            } else {
+                              sortedUsers = users;
+                            }
+
+                            return Row(
+                              mainAxisAlignment: MainAxisAlignment.start,
+                              children: sortedUsers.map((user) {
+                                bool isSelected =
+                                    selectedUserNickname == user.nickname;
+
+                                return GestureDetector(
+                                  onTap: () {
+                                    setState(() {
+                                      if (selectedUserNickname ==
+                                          user.nickname) {
+                                        selectedUserNickname = null;
+                                      } else {
+                                        selectedUserNickname = user.nickname;
+                                      }
+                                    });
+                                  },
+                                  child: MissionFeedSelectProfile(
+                                    user: user,
+                                    isSelected: isSelected,
+                                  ),
+                                );
+                              }).toList(),
+                            );
+                          },
+                          loading: () => const CircularProgressIndicator(),
+                          error: (err, stack) => Text('Error: $err'),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: Column(
-                  children: feeds.isEmpty
-                      ? const [
-                          SizedBox(
-                            width: double.infinity,
-                            child: ContentEmpty(
-                              text: '아직 미션을 완료한 파머가 없어요',
-                              padding: 48.0,
-                            ),
-                          )
-                        ]
-                      : feeds.map((feed) {
-                          return FarmusFeed(
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Column(
+                    children: filteredFeeds.isEmpty
+                        ? const [
+                            SizedBox(
+                              width: double.infinity,
+                              child: ContentEmpty(
+                                text: '아직 완료한 미션이 없어요',
+                                padding: 48.0,
+                              ),
+                            )
+                          ]
+                        : filteredFeeds.map((feed) {
+                            return FarmusFeed(
                               feedId: feed.missionPostId,
                               profileImage: feed.profileImage,
                               nickname: feed.nickname,
@@ -70,19 +129,21 @@ class MissionFeedTabBar extends ConsumerWidget {
                               image: feed.image,
                               commentCount: feed.commentCount,
                               likeCount: feed.likeCount,
-                              myLike: feed.isLiked);
-                        }).toList(),
+                              myLike: feed.isLiked,
+                            );
+                          }).toList(),
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ),
+              ],
+            ),
+          );
+        },
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, stack) => Center(child: Text('Error: $err')),
       ),
     );
 
-    for (var step in farmclubInfo.steps) {
+    for (var step in widget.farmclubInfo.steps) {
       tabViews.add(
         missionFeed.when(
           data: (feeds) {
@@ -110,15 +171,16 @@ class MissionFeedTabBar extends ConsumerWidget {
                         : Column(
                             children: stepFeeds.map((feed) {
                               return FarmusFeed(
-                                  feedId: feed.missionPostId,
-                                  profileImage: feed.profileImage,
-                                  nickname: feed.nickname,
-                                  writeDateTime: feed.date,
-                                  content: feed.content,
-                                  image: feed.image,
-                                  commentCount: feed.commentCount,
-                                  likeCount: feed.likeCount,
-                                  myLike: feed.isLiked);
+                                feedId: feed.missionPostId,
+                                profileImage: feed.profileImage,
+                                nickname: feed.nickname,
+                                writeDateTime: feed.date,
+                                content: feed.content,
+                                image: feed.image,
+                                commentCount: feed.commentCount,
+                                likeCount: feed.likeCount,
+                                myLike: feed.isLiked,
+                              );
                             }).toList(),
                           ),
                   ],
@@ -134,7 +196,9 @@ class MissionFeedTabBar extends ConsumerWidget {
 
     return PrimaryTabBar(
       tab: ['전체'] +
-          farmclubInfo.steps.map((step) => 'Step ${step.stepNum}').toList(),
+          widget.farmclubInfo.steps
+              .map((step) => 'Step ${step.stepNum}')
+              .toList(),
       tabView: tabViews,
     );
   }

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -109,7 +109,7 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                       SizedBox(
                         width: double.infinity,
                         child: ContentEmpty(
-                          text: '아직 완료한 미션이 없어요',
+                          text: '아직 미션을 완료하지 않았어요',
                           padding: 48.0,
                         ),
                       )

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -49,6 +49,7 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
 
           return SingleChildScrollView(
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
                   padding: const EdgeInsets.symmetric(
@@ -75,7 +76,6 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                             }
 
                             return Row(
-                              mainAxisAlignment: MainAxisAlignment.start,
                               children: sortedUsers.map((user) {
                                 bool isSelected =
                                     selectedUserNickname == user.nickname;

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -69,11 +69,7 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                                 .toList();
 
                             List<MissionUserListModel> sortedUsers = [];
-                            if (myAccount != null) {
-                              sortedUsers = [myAccount, ...otherUsers];
-                            } else {
-                              sortedUsers = users;
-                            }
+                            sortedUsers = [myAccount, ...otherUsers];
 
                             return Row(
                               children: sortedUsers.map((user) {

--- a/lib/view_model/mission_feed/mission_user_list_model_notifier.dart
+++ b/lib/view_model/mission_feed/mission_user_list_model_notifier.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+import 'package:farmus/repository/my_farmclub_repository.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../model/mission/mission_user_list_model.dart';
+import '../my_farmclub/my_farmclub_notifier.dart';
+
+part 'mission_user_list_model_notifier.g.dart';
+
+@riverpod
+Future<List<MissionUserListModel>> missionUserListModel(
+    MissionUserListModelRef ref, int? farmClubId) async {
+  if (farmClubId == null) {
+    final farmClubList = await ref.watch(myFarmclubModelProvider.future);
+    farmClubId = farmClubList.first.farmClubId.toInt();
+  }
+
+  final response = await MyFarmclubRepository.farmclubUserList(farmClubId);
+  final json = jsonDecode(response);
+  final data = json['data'] as Map<String, dynamic>;
+  final dataList = data['userList'] as List<dynamic>;
+
+  final List<MissionUserListModel> missionUserList = dataList
+      .map((data) => MissionUserListModel.fromJson(data as Map<String, dynamic>))
+      .toList();
+
+  return missionUserList;
+}

--- a/lib/view_model/mission_feed/mission_user_list_model_notifier.g.dart
+++ b/lib/view_model/mission_feed/mission_user_list_model_notifier.g.dart
@@ -1,0 +1,166 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_user_list_model_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$missionUserListModelHash() =>
+    r'4f172351d94c22d7fc55cc1348174467ae8c37ef';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [missionUserListModel].
+@ProviderFor(missionUserListModel)
+const missionUserListModelProvider = MissionUserListModelFamily();
+
+/// See also [missionUserListModel].
+class MissionUserListModelFamily
+    extends Family<AsyncValue<List<MissionUserListModel>>> {
+  /// See also [missionUserListModel].
+  const MissionUserListModelFamily();
+
+  /// See also [missionUserListModel].
+  MissionUserListModelProvider call(
+    int? farmClubId,
+  ) {
+    return MissionUserListModelProvider(
+      farmClubId,
+    );
+  }
+
+  @override
+  MissionUserListModelProvider getProviderOverride(
+    covariant MissionUserListModelProvider provider,
+  ) {
+    return call(
+      provider.farmClubId,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'missionUserListModelProvider';
+}
+
+/// See also [missionUserListModel].
+class MissionUserListModelProvider
+    extends AutoDisposeFutureProvider<List<MissionUserListModel>> {
+  /// See also [missionUserListModel].
+  MissionUserListModelProvider(
+    int? farmClubId,
+  ) : this._internal(
+          (ref) => missionUserListModel(
+            ref as MissionUserListModelRef,
+            farmClubId,
+          ),
+          from: missionUserListModelProvider,
+          name: r'missionUserListModelProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$missionUserListModelHash,
+          dependencies: MissionUserListModelFamily._dependencies,
+          allTransitiveDependencies:
+              MissionUserListModelFamily._allTransitiveDependencies,
+          farmClubId: farmClubId,
+        );
+
+  MissionUserListModelProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.farmClubId,
+  }) : super.internal();
+
+  final int? farmClubId;
+
+  @override
+  Override overrideWith(
+    FutureOr<List<MissionUserListModel>> Function(
+            MissionUserListModelRef provider)
+        create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: MissionUserListModelProvider._internal(
+        (ref) => create(ref as MissionUserListModelRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        farmClubId: farmClubId,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<List<MissionUserListModel>> createElement() {
+    return _MissionUserListModelProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MissionUserListModelProvider &&
+        other.farmClubId == farmClubId;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, farmClubId.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin MissionUserListModelRef
+    on AutoDisposeFutureProviderRef<List<MissionUserListModel>> {
+  /// The parameter `farmClubId` of this provider.
+  int? get farmClubId;
+}
+
+class _MissionUserListModelProviderElement
+    extends AutoDisposeFutureProviderElement<List<MissionUserListModel>>
+    with MissionUserListModelRef {
+  _MissionUserListModelProviderElement(super.provider);
+
+  @override
+  int? get farmClubId => (origin as MissionUserListModelProvider).farmClubId;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #270


### 🍠 Summary
미션 인증 목록 조회(유저) API 연동을 하였습니다.
특정 프로필을 클릭하면 해당 유저의 미션들만 보이고 다시 한 번 클릭하면 모든 유저의 미션들이 보입니다.

https://github.com/user-attachments/assets/bc52f01c-7c6f-46ee-9c21-be8fb3ee0530



### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [x] Other


### 🫛 Other Information
