### PR TITLE
[Feat] 미션 글 및 댓글 삭제 API 연동

### DIFF
--- a/lib/common/bottom_sheet/delete_bottom_sheet_content.dart
+++ b/lib/common/bottom_sheet/delete_bottom_sheet_content.dart
@@ -4,24 +4,31 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../view_model/mission_write/notifier/mission_commemt_delete_notifier.dart';
+import '../../view_model/mission_write/notifier/mission_delete_notifier.dart';
 import '../button/primary_color_button.dart';
 import '../button/white_color_button.dart';
 import '../dialog/check_dialog.dart';
 import '../theme/farmus_theme_text_style.dart';
 
 class DeleteBottomSheetContent extends ConsumerWidget {
-  const DeleteBottomSheetContent(
-      {super.key, required this.id, this.myVeggieId, required this.type});
+  const DeleteBottomSheetContent({
+    super.key,
+    required this.id,
+    this.myVeggieId,
+    required this.contentType,
+    required this.categoryType,
+  });
 
   final int id;
   final int? myVeggieId;
-  final String type;
+  final String contentType;
+  final String categoryType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
-      padding:
-          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
       child: SizedBox(
         child: SingleChildScrollView(
           child: Column(
@@ -38,7 +45,7 @@ class DeleteBottomSheetContent extends ConsumerWidget {
                         children: [
                           Center(
                             child: Text(
-                              '$type을 삭제하시겠어요?',
+                              '$contentType을 삭제하시겠어요?',
                               style: FarmusThemeTextStyle.gray1Medium15,
                             ),
                           ),
@@ -61,43 +68,84 @@ class DeleteBottomSheetContent extends ConsumerWidget {
                                   text: '삭제',
                                   onPressed: () {
                                     Navigator.pop(context);
-                                    switch (type) {
-                                      case '댓글':
-                                        ref
-                                            .read(
-                                                diaryCommentDeleteNotifierProvider
-                                                    .notifier)
-                                            .diaryCommentDelete(id);
-                                        showDialog(
-                                          context: context,
-                                          builder: (BuildContext context) {
-                                            Future.delayed(const Duration(seconds: 2), () {
-                                              Navigator.of(context).pop();
-                                            });
-                                            return const CheckDialog(
-                                              text: '댓글이 삭제 되었어요',
-                                            );
-                                          },
-                                        );
-                                        break;
-                                      case '게시물':
-                                        ref
-                                            .read(diaryDeleteNotifierProvider
-                                                .notifier)
-                                            .diaryDelete(id, myVeggieId!);
-                                        Navigator.pop(context);
-                                        showDialog(
-                                          context: context,
-                                          builder: (BuildContext context) {
-                                            Future.delayed(const Duration(seconds: 2), () {
-                                              Navigator.of(context).pop();
-                                            });
-                                            return const CheckDialog(
-                                              text: '게시물이 삭제 되었어요',
-                                            );
-                                          },
-                                        );
-                                        break;
+                                    if (categoryType == 'diary') {
+                                      switch (contentType) {
+                                        case '댓글':
+                                          ref
+                                              .read(diaryCommentDeleteNotifierProvider
+                                              .notifier)
+                                              .diaryCommentDelete(id);
+                                          showDialog(
+                                            context: context,
+                                            builder: (BuildContext context) {
+                                              Future.delayed(
+                                                  const Duration(seconds: 2), () {
+                                                Navigator.of(context).pop();
+                                              });
+                                              return const CheckDialog(
+                                                text: '댓글이 삭제 되었어요',
+                                              );
+                                            },
+                                          );
+                                          break;
+                                        case '게시물':
+                                          ref
+                                              .read(diaryDeleteNotifierProvider
+                                              .notifier)
+                                              .diaryDelete(id, myVeggieId!);
+                                          showDialog(
+                                            context: context,
+                                            builder: (BuildContext context) {
+                                              Future.delayed(
+                                                  const Duration(seconds: 2), () {
+                                                Navigator.of(context).pop();
+                                              });
+                                              return const CheckDialog(
+                                                text: '게시물이 삭제 되었어요',
+                                              );
+                                            },
+                                          );
+                                          break;
+                                      }
+                                    } else if (categoryType == 'mission') {
+                                      switch (contentType) {
+                                        case '댓글':
+                                          ref
+                                              .read(missionCommentDeleteNotifierProvider
+                                              .notifier)
+                                              .missionCommentDelete(id);
+                                          showDialog(
+                                            context: context,
+                                            builder: (BuildContext context) {
+                                              Future.delayed(
+                                                  const Duration(seconds: 2), () {
+                                                Navigator.of(context).pop();
+                                              });
+                                              return const CheckDialog(
+                                                text: '댓글이 삭제 되었어요',
+                                              );
+                                            },
+                                          );
+                                          break;
+                                        case '게시물':
+                                          ref
+                                              .read(missionDeleteNotifierProvider
+                                              .notifier)
+                                              .missionDelete(id);
+                                          showDialog(
+                                            context: context,
+                                            builder: (BuildContext context) {
+                                              Future.delayed(
+                                                  const Duration(seconds: 2), () {
+                                                Navigator.of(context).pop();
+                                              });
+                                              return const CheckDialog(
+                                                text: '게시물이 삭제 되었어요',
+                                              );
+                                            },
+                                          );
+                                          break;
+                                      }
                                     }
                                   },
                                   enabled: true,

--- a/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
+++ b/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
@@ -117,13 +117,15 @@ void showQuitActionSheet(BuildContext context) {
       });
 }
 
-void showFarmclubExitBottomSheet(BuildContext context, String farmClubName, int farmClubId) {
+void showFarmclubExitBottomSheet(
+    BuildContext context, String farmClubName, int farmClubId) {
   showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: FarmusThemeColor.white,
     builder: (BuildContext context) {
-      return FarmclubExitBottomSheetContent(farmClubName: farmClubName, farmClubId : farmClubId);
+      return FarmclubExitBottomSheetContent(
+          farmClubName: farmClubName, farmClubId: farmClubId);
     },
   );
 }
@@ -156,15 +158,18 @@ void showVeggieDeleteBottomSheet(BuildContext context) {
   );
 }
 
-void showDeleteBottomSheet(
-    BuildContext context, int id, int? myVeggieId, String type) {
+void showDeleteBottomSheet(BuildContext context, int id, int? myVeggieId,
+    String contentType, String categoryType) {
   showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: FarmusThemeColor.white,
     builder: (BuildContext context) {
       return DeleteBottomSheetContent(
-          id: id, myVeggieId: myVeggieId, type: type);
+          id: id,
+          myVeggieId: myVeggieId,
+          contentType: contentType,
+          categoryType: categoryType);
     },
   );
 }

--- a/lib/common/farmus_feed.dart
+++ b/lib/common/farmus_feed.dart
@@ -18,6 +18,8 @@ class FarmusFeed extends ConsumerWidget {
     required this.commentCount,
     required this.likeCount,
     required this.myLike,
+    required this.categoryType,
+
     this.state,
   });
 
@@ -31,6 +33,7 @@ class FarmusFeed extends ConsumerWidget {
   final int likeCount;
   final bool myLike;
   final String? state;
+  final String categoryType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -49,6 +52,7 @@ class FarmusFeed extends ConsumerWidget {
                     likeCount: likeCount,
                     myLike: myLike,
                     state: state,
+                    categoryType: categoryType,
                   ))),
       child: Column(
         children: [
@@ -61,6 +65,7 @@ class FarmusFeed extends ConsumerWidget {
               profileImage: profileImage,
               myComment: false,
               commentId: -1,
+              categoryType: categoryType,
             ),
           ),
           FeedDetailContent(

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -204,4 +204,35 @@ class MyFarmclubService {
       throw Exception('미션 좋아요 삭제 실패');
     }
   }
+
+  Future<String> missionCommentDelete(int missionPostCommentId) async {
+    final url = '/api/farm-club/mission/comment/$missionPostCommentId';
+
+    final body = jsonEncode({
+      'missionPostCommentId': missionPostCommentId,
+    });
+
+    final response = await apiClient.delete(url, body: body);
+
+    if (response.statusCode == 200) {
+      return utf8.decode(response.bodyBytes);
+    } else {
+      throw Exception('미션 댓글 삭제 실패');
+    }
+  }
+
+  Future<String> missionDelete(int missionPostId) async {
+    final url = '/api/farm-club/mission/$missionPostId';
+    final body = jsonEncode({
+      'missionPostId': missionPostId,
+    });
+
+    final response = await apiClient.delete(url, body: body);
+
+    if (response.statusCode == 200) {
+      return utf8.decode(response.bodyBytes);
+    } else {
+      throw Exception('미션 삭제 실패');
+    }
+  }
 }

--- a/lib/repository/my_farmclub_repository.dart
+++ b/lib/repository/my_farmclub_repository.dart
@@ -76,4 +76,16 @@ class MyFarmclubRepository {
     String? response = await MyFarmclubService().myMissionSuccess(farmClubId);
     return response;
   }
+
+  static Future<String> missionCommentDelete(int missionPostCommentId) async {
+    String? response =
+    await MyFarmclubService().missionCommentDelete(missionPostCommentId);
+    return response;
+  }
+
+  static Future<String> missionDelete(int missionPostId) async {
+    String? response =
+    await MyFarmclubService().missionDelete(missionPostId);
+    return response;
+  }
 }

--- a/lib/view/farmclub/component/feed_profile.dart
+++ b/lib/view/farmclub/component/feed_profile.dart
@@ -15,6 +15,7 @@ class FeedProfile extends ConsumerWidget {
     required this.writeDateTime,
     required this.myComment,
     required this.commentId,
+    required this.categoryType,
   });
 
   final String? profileImage;
@@ -23,6 +24,7 @@ class FeedProfile extends ConsumerWidget {
   final String writeDateTime;
   final bool myComment;
   final int commentId;
+  final String categoryType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -49,8 +51,8 @@ class FeedProfile extends ConsumerWidget {
                         ? GestureDetector(
                             onTap: myComment
                                 ? () {
-                                    showDeleteBottomSheet(
-                                        context, commentId, null, '댓글');
+                                    showDeleteBottomSheet(context, commentId,
+                                        null, '댓글', categoryType);
                                   }
                                 : () {
                                     showReportBottomSheet(

--- a/lib/view/farmclub/farmclub_screen.dart
+++ b/lib/view/farmclub/farmclub_screen.dart
@@ -142,6 +142,7 @@ class FarmclubScreen extends ConsumerWidget {
                                             likeCount: diary.likeCount,
                                             myLike: diary.myLike,
                                             state: diary.state,
+                                            categoryType: 'diary',
                                           );
                                         }).toList(),
                                       )

--- a/lib/view/feed_detail/component/diary_comment.dart
+++ b/lib/view/feed_detail/component/diary_comment.dart
@@ -80,6 +80,7 @@ class DiaryComment extends ConsumerWidget {
                                 commentsData.diaryCommentContent.length - 1,
                             myComment: comment.myComment,
                             commentId: comment.commentId,
+                            categoryType: "diary",
                           ),
                         );
                       }).toList(),

--- a/lib/view/feed_detail/component/feed_detail_comment.dart
+++ b/lib/view/feed_detail/component/feed_detail_comment.dart
@@ -15,6 +15,7 @@ class FeedDetailComment extends ConsumerWidget {
     this.isLast = false,
     required this.myComment,
     required this.commentId,
+    required this.categoryType,
   });
 
   final String? profileImage;
@@ -24,6 +25,7 @@ class FeedDetailComment extends ConsumerWidget {
   final bool isLast;
   final bool myComment;
   final int commentId;
+  final String categoryType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -37,6 +39,7 @@ class FeedDetailComment extends ConsumerWidget {
           profileImage: profileImage,
           myComment: myComment,
           commentId: commentId,
+          categoryType: categoryType,
         ),
         const SizedBox(
           height: 6.0,

--- a/lib/view/feed_detail/feed_detail_screen.dart
+++ b/lib/view/feed_detail/feed_detail_screen.dart
@@ -28,6 +28,7 @@ class FeedDetailScreen extends ConsumerWidget {
     required this.likeCount,
     required this.myLike,
     this.state,
+    required this.categoryType,
   });
 
   final int feedId;
@@ -40,12 +41,13 @@ class FeedDetailScreen extends ConsumerWidget {
   final int likeCount;
   final bool myLike;
   final String? state;
+  final String categoryType;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     var selectedVeggieId = ref.watch(selectedVegeIdProvider);
     final AsyncValue<List<MyVeggieListModel>> veggieList =
-    ref.watch(myVeggieListModelProvider);
+        ref.watch(myVeggieListModelProvider);
 
     if (selectedVeggieId == null && veggieList.value?.isNotEmpty == true) {
       selectedVeggieId = veggieList.value!.first.myVeggieId;
@@ -59,11 +61,7 @@ class FeedDetailScreen extends ConsumerWidget {
           IconButton(
             onPressed: () {
               showDeleteBottomSheet(
-                context,
-                feedId,
-                selectedVeggieId,
-                '게시물',
-              );
+                  context, feedId, selectedVeggieId, '게시물', categoryType);
             },
             icon: SvgPicture.asset('assets/image/ic_more_vertical.svg'),
           )
@@ -80,13 +78,13 @@ class FeedDetailScreen extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     FeedProfile(
-                      isDetail: false,
-                      profileImage: profileImage,
-                      nickname: nickname,
-                      writeDateTime: writeDateTime,
-                      myComment: false,
-                      commentId: commentCount,
-                    ),
+                        isDetail: false,
+                        profileImage: profileImage,
+                        nickname: nickname,
+                        writeDateTime: writeDateTime,
+                        myComment: false,
+                        commentId: commentCount,
+                        categoryType: categoryType),
                     const SizedBox(
                       height: 16.0,
                     ),
@@ -123,15 +121,15 @@ class FeedDetailScreen extends ConsumerWidget {
                     ],
                     state != null
                         ? DiaryComment(
-                      diaryId: feedId,
-                      commentCount: commentCount,
-                      myLike: myLike,
-                    )
+                            diaryId: feedId,
+                            commentCount: commentCount,
+                            myLike: myLike,
+                          )
                         : MissionComment(
-                      missionPostCommentId: feedId,
-                      commentCount: commentCount,
-                      myLike: myLike,
-                    ),
+                            missionPostCommentId: feedId,
+                            commentCount: commentCount,
+                            myLike: myLike,
+                          ),
                   ],
                 ),
               ),

--- a/lib/view/mission_feed/component/mission_comment.dart
+++ b/lib/view/mission_feed/component/mission_comment.dart
@@ -92,6 +92,7 @@ class MissionComment extends ConsumerWidget {
                               isLast: idx == comments.length - 1,
                               myComment: comment.isMyComment,
                               commentId: comment.missionPostCommentId,
+                              categoryType: 'mission',
                             ),
                           );
                         }).toList(),

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -62,15 +62,17 @@ class MissionFeedTabBar extends ConsumerWidget {
                         ]
                       : feeds.map((feed) {
                           return FarmusFeed(
-                              feedId: feed.missionPostId,
-                              profileImage: feed.profileImage,
-                              nickname: feed.nickname,
-                              writeDateTime: feed.date,
-                              content: feed.content,
-                              image: feed.image,
-                              commentCount: feed.commentCount,
-                              likeCount: feed.likeCount,
-                              myLike: feed.isLiked);
+                            feedId: feed.missionPostId,
+                            profileImage: feed.profileImage,
+                            nickname: feed.nickname,
+                            writeDateTime: feed.date,
+                            content: feed.content,
+                            image: feed.image,
+                            commentCount: feed.commentCount,
+                            likeCount: feed.likeCount,
+                            myLike: feed.isLiked,
+                            categoryType: 'mission',
+                          );
                         }).toList(),
                 ),
               ),
@@ -110,15 +112,17 @@ class MissionFeedTabBar extends ConsumerWidget {
                         : Column(
                             children: stepFeeds.map((feed) {
                               return FarmusFeed(
-                                  feedId: feed.missionPostId,
-                                  profileImage: feed.profileImage,
-                                  nickname: feed.nickname,
-                                  writeDateTime: feed.date,
-                                  content: feed.content,
-                                  image: feed.image,
-                                  commentCount: feed.commentCount,
-                                  likeCount: feed.likeCount,
-                                  myLike: feed.isLiked);
+                                feedId: feed.missionPostId,
+                                profileImage: feed.profileImage,
+                                nickname: feed.nickname,
+                                writeDateTime: feed.date,
+                                content: feed.content,
+                                image: feed.image,
+                                commentCount: feed.commentCount,
+                                likeCount: feed.likeCount,
+                                myLike: feed.isLiked,
+                                categoryType: 'mission',
+                              );
                             }).toList(),
                           ),
                   ],

--- a/lib/view/vege_diary/component/vege_diary_widget.dart
+++ b/lib/view/vege_diary/component/vege_diary_widget.dart
@@ -37,6 +37,7 @@ class VegeDiaryWidget extends ConsumerWidget {
               likeCount: diary.likeCount,
               myLike: diary.myLike,
               state: diary.state,
+              categoryType: 'diary',
             ),
           ),
         );

--- a/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart
@@ -1,10 +1,9 @@
-import 'package:farmus/repository/my_veggie_garden_repository.dart';
 import 'package:farmus/view_model/my_farmclub/mission_comment_add_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../../../data/network/my_farmclub_service.dart';
 import '../../my_farmclub/mission_comment_notifier.dart';
-
-
+import '../../my_farmclub/mission_feed_notifier.dart';
 
 part 'mission_commemt_delete_notifier.g.dart';
 
@@ -15,12 +14,14 @@ class MissionCommentDeleteNotifier extends _$MissionCommentDeleteNotifier {
     return '';
   }
 
-  Future<void> diaryCommentDelete(int diaryCommentId) async {
-    await MyVeggieGardenRepository.diaryCommentDelete(diaryCommentId);
+  Future<void> missionCommentDelete(int missionPostCommentId) async {
+    await MyFarmclubService().missionCommentDelete(missionPostCommentId);
 
     state = const AsyncData('');
 
     ref.invalidate(missionCommentNotifierProvider);
     ref.invalidate(missionCommentAddNotifierProvider);
+    ref.invalidate(missionFeedProvider);
+    ref.invalidateSelf();
   }
 }

--- a/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart
@@ -1,0 +1,26 @@
+import 'package:farmus/repository/my_veggie_garden_repository.dart';
+import 'package:farmus/view_model/my_farmclub/mission_comment_add_notifier.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../my_farmclub/mission_comment_notifier.dart';
+
+
+
+part 'mission_commemt_delete_notifier.g.dart';
+
+@riverpod
+class MissionCommentDeleteNotifier extends _$MissionCommentDeleteNotifier {
+  @override
+  Future<String> build() async {
+    return '';
+  }
+
+  Future<void> diaryCommentDelete(int diaryCommentId) async {
+    await MyVeggieGardenRepository.diaryCommentDelete(diaryCommentId);
+
+    state = const AsyncData('');
+
+    ref.invalidate(missionCommentNotifierProvider);
+    ref.invalidate(missionCommentAddNotifierProvider);
+  }
+}

--- a/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.g.dart
+++ b/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_commemt_delete_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$missionCommentDeleteNotifierHash() =>
+    r'04f3cdc1bedf71028af3471e4024bf251011abae';
+
+/// See also [MissionCommentDeleteNotifier].
+@ProviderFor(MissionCommentDeleteNotifier)
+final missionCommentDeleteNotifierProvider = AutoDisposeAsyncNotifierProvider<
+    MissionCommentDeleteNotifier, String>.internal(
+  MissionCommentDeleteNotifier.new,
+  name: r'missionCommentDeleteNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$missionCommentDeleteNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$MissionCommentDeleteNotifier = AutoDisposeAsyncNotifier<String>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.g.dart
+++ b/lib/view_model/mission_write/notifier/mission_commemt_delete_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'mission_commemt_delete_notifier.dart';
 // **************************************************************************
 
 String _$missionCommentDeleteNotifierHash() =>
-    r'04f3cdc1bedf71028af3471e4024bf251011abae';
+    r'0ef941978a34785a452863f8d60a32b6018511d3';
 
 /// See also [MissionCommentDeleteNotifier].
 @ProviderFor(MissionCommentDeleteNotifier)

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
@@ -1,7 +1,6 @@
-import 'package:farmus/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart';
-import 'package:farmus/view_model/my_farmclub/mission_comment_add_notifier.dart';
+import 'package:farmus/view_model/my_farmclub/farmclub_mission_certification_notifier.dart';
 import 'package:farmus/view_model/my_farmclub/mission_feed_notifier.dart';
-import 'package:farmus/view_model/my_farmclub/mission_like_notifier.dart';
+import 'package:farmus/view_model/my_farmclub/my_farmclub_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../data/network/my_farmclub_service.dart';
@@ -17,8 +16,9 @@ class MissionDeleteNotifier extends _$MissionDeleteNotifier {
 
   Future<void> missionDelete(int missionPostId) async {
     await MyFarmclubService().missionDelete(missionPostId);
-    ref.invalidate(missionCommentDeleteNotifierProvider);
     ref.invalidate(missionFeedProvider);
+    ref.invalidate(myFarmclubModelProvider);
+    ref.invalidate(farmclubMissionCertificationNotifierProvider);
     ref.invalidateSelf();
   }
 }

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
@@ -1,16 +1,15 @@
-import 'package:farmus/repository/my_history_repository.dart';
-import 'package:farmus/repository/my_veggie_garden_repository.dart';
-import 'package:farmus/view_model/diary/diary_check_notifier.dart';
+import 'package:farmus/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart';
+import 'package:farmus/view_model/my_farmclub/mission_comment_add_notifier.dart';
 import 'package:farmus/view_model/my_farmclub/mission_feed_notifier.dart';
+import 'package:farmus/view_model/my_farmclub/mission_like_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../data/network/my_farmclub_service.dart';
 
-
 part 'mission_delete_notifier.g.dart';
 
 @riverpod
-class DiaryDeleteNotifier extends _$DiaryDeleteNotifier {
+class MissionDeleteNotifier extends _$MissionDeleteNotifier {
   @override
   Future<void> build() async {
     return;
@@ -18,6 +17,7 @@ class DiaryDeleteNotifier extends _$DiaryDeleteNotifier {
 
   Future<void> missionDelete(int missionPostId) async {
     await MyFarmclubService().missionDelete(missionPostId);
+    ref.invalidate(missionCommentDeleteNotifierProvider);
     ref.invalidate(missionFeedProvider);
     ref.invalidateSelf();
   }

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
@@ -1,0 +1,24 @@
+import 'package:farmus/repository/my_history_repository.dart';
+import 'package:farmus/repository/my_veggie_garden_repository.dart';
+import 'package:farmus/view_model/diary/diary_check_notifier.dart';
+import 'package:farmus/view_model/my_farmclub/mission_feed_notifier.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../data/network/my_farmclub_service.dart';
+
+
+part 'mission_delete_notifier.g.dart';
+
+@riverpod
+class DiaryDeleteNotifier extends _$DiaryDeleteNotifier {
+  @override
+  Future<void> build() async {
+    return;
+  }
+
+  Future<void> missionDelete(int missionPostId) async {
+    await MyFarmclubService().missionDelete(missionPostId);
+    ref.invalidate(missionFeedProvider);
+    ref.invalidateSelf();
+  }
+}

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.g.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'mission_delete_notifier.dart';
 // **************************************************************************
 
 String _$missionDeleteNotifierHash() =>
-    r'dbe48791f56dedcfe6bbe461ecdc14e826ebb22c';
+    r'f4c095307f6b9ee108cbbbcbff19bf505c0bedcb';
 
 /// See also [MissionDeleteNotifier].
 @ProviderFor(MissionDeleteNotifier)

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.g.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_delete_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$diaryDeleteNotifierHash() =>
+    r'522cf336a006301bbfb2de9b9522fb17b85309ce';
+
+/// See also [DiaryDeleteNotifier].
+@ProviderFor(DiaryDeleteNotifier)
+final diaryDeleteNotifierProvider =
+    AutoDisposeAsyncNotifierProvider<DiaryDeleteNotifier, void>.internal(
+  DiaryDeleteNotifier.new,
+  name: r'diaryDeleteNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$diaryDeleteNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$DiaryDeleteNotifier = AutoDisposeAsyncNotifier<void>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.g.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.g.dart
@@ -6,22 +6,22 @@ part of 'mission_delete_notifier.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$diaryDeleteNotifierHash() =>
-    r'522cf336a006301bbfb2de9b9522fb17b85309ce';
+String _$missionDeleteNotifierHash() =>
+    r'dbe48791f56dedcfe6bbe461ecdc14e826ebb22c';
 
-/// See also [DiaryDeleteNotifier].
-@ProviderFor(DiaryDeleteNotifier)
-final diaryDeleteNotifierProvider =
-    AutoDisposeAsyncNotifierProvider<DiaryDeleteNotifier, void>.internal(
-  DiaryDeleteNotifier.new,
-  name: r'diaryDeleteNotifierProvider',
+/// See also [MissionDeleteNotifier].
+@ProviderFor(MissionDeleteNotifier)
+final missionDeleteNotifierProvider =
+    AutoDisposeAsyncNotifierProvider<MissionDeleteNotifier, void>.internal(
+  MissionDeleteNotifier.new,
+  name: r'missionDeleteNotifierProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
-      : _$diaryDeleteNotifierHash,
+      : _$missionDeleteNotifierHash,
   dependencies: null,
   allTransitiveDependencies: null,
 );
 
-typedef _$DiaryDeleteNotifier = AutoDisposeAsyncNotifier<void>;
+typedef _$MissionDeleteNotifier = AutoDisposeAsyncNotifier<void>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/vege_delete/notifier/vege_delete_success_notifier.g.dart
+++ b/lib/view_model/vege_delete/notifier/vege_delete_success_notifier.g.dart
@@ -7,7 +7,7 @@ part of 'vege_delete_success_notifier.dart';
 // **************************************************************************
 
 String _$vegeDeleteSuccessNotifierHash() =>
-    r'a3b6ce3df756c75e650c6f35c8a0bfde7223a50b';
+    r'2db7bfa6b6d8c2f4768da6528d1e21171f63362c';
 
 /// See also [VegeDeleteSuccessNotifier].
 @ProviderFor(VegeDeleteSuccessNotifier)


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #273


### 🍠 Summary
미션 글 및 댓글 삭제 API 연동을 하였습니다.
categoryType에 diary라고 입력을 하면, 성장 일기에 대한 notifier이 적용되고 mission이라고 입력하면 미션 인증에 대한 notifier이 적용이 됩니다.

https://github.com/user-attachments/assets/4c690def-2f8f-4ab5-8509-5de974377d95


### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [ ] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
