### PR TITLE
[Feat] 미션 글 & 댓글 신고 API 연동

### DIFF
--- a/lib/common/bottom_sheet/report_bottom_sheet.dart
+++ b/lib/common/bottom_sheet/report_bottom_sheet.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../view_model/mission_feed/mission_post_report_notifier.dart';
+import '../../view_model/mission_feed/mission_comment_report_notifier.dart'; // Add the comment report notifier
 import '../dialog/check_dialog.dart';
 import '../theme/farmus_theme_text_style.dart';
 
@@ -10,13 +12,34 @@ class ReportBottomSheet extends ConsumerWidget {
     super.key,
     required this.title,
     required this.dialogText,
+    this.reportId,
+    this.reportType,
   });
 
   final String title;
   final String dialogText;
+  final int? reportId;
+  final String? reportType;
 
-  void _report(BuildContext context, String reportType) {
+  void _report(BuildContext context, WidgetRef ref, String reason) {
     Navigator.pop(context);
+
+    if (reportType == 'missionPost') {
+      ref
+          .read(missionPostReportModelProvider(reportId!, reason).future)
+          .then((value) {
+        _showConfirmationDialog(context);
+      });
+    } else if (reportType == 'missionComment') {
+      ref
+          .read(missionCommentReportNotifierProvider(reportId!, reason).future)
+          .then((value) {
+        _showConfirmationDialog(context);
+      });
+    }
+  }
+
+  void _showConfirmationDialog(BuildContext context) {
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -47,7 +70,7 @@ class ReportBottomSheet extends ConsumerWidget {
       ),
       actions: reportOptions.map((option) {
         return CupertinoActionSheetAction(
-          onPressed: () => _report(context, option),
+          onPressed: () => _report(context, ref, option),
           child: Text(
             option,
             style: FarmusThemeTextStyle.darkMedium14,

--- a/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
+++ b/lib/common/bottom_sheet/show_farmus_bottom_sheet.dart
@@ -175,13 +175,16 @@ void showDeleteBottomSheet(BuildContext context, int id, int? myVeggieId,
 }
 
 void showReportBottomSheet(
-    BuildContext context, String title, String dialogText) {
+    BuildContext context, String title, String dialogText, int? reportId, String? reportType) {
   showCupertinoModalPopup(
     context: context,
     builder: (BuildContext context) {
+      print(reportId);
       return ReportBottomSheet(
         title: title,
         dialogText: dialogText,
+        reportId: reportId,
+        reportType: reportType,
       );
     },
   );

--- a/lib/common/farmus_feed.dart
+++ b/lib/common/farmus_feed.dart
@@ -19,8 +19,8 @@ class FarmusFeed extends ConsumerWidget {
     required this.likeCount,
     required this.myLike,
     required this.categoryType,
-
     this.state,
+    required this.myPost
   });
 
   final int feedId;
@@ -34,6 +34,7 @@ class FarmusFeed extends ConsumerWidget {
   final bool myLike;
   final String? state;
   final String categoryType;
+  final bool myPost;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -53,6 +54,7 @@ class FarmusFeed extends ConsumerWidget {
                     myLike: myLike,
                     state: state,
                     categoryType: categoryType,
+                    myPost: myPost,
                   ))),
       child: Column(
         children: [
@@ -64,7 +66,9 @@ class FarmusFeed extends ConsumerWidget {
               writeDateTime: writeDateTime,
               profileImage: profileImage,
               myComment: false,
+              myPost: false,
               commentId: -1,
+              feedId : -1,
               categoryType: categoryType,
             ),
           ),

--- a/lib/common/farmus_feed.dart
+++ b/lib/common/farmus_feed.dart
@@ -68,7 +68,7 @@ class FarmusFeed extends ConsumerWidget {
               myComment: false,
               myPost: false,
               commentId: -1,
-              feedId : -1,
+              feedId : feedId,
               categoryType: categoryType,
             ),
           ),

--- a/lib/data/network/my_farmclub_service.dart
+++ b/lib/data/network/my_farmclub_service.dart
@@ -235,4 +235,38 @@ class MyFarmclubService {
     final url = '/api/farm-club/$farmClubId/user';
     return _fetchData(url, '팜클럽 유저 불러오기 실패');
   }
+
+  Future<String> missionReport(int missionPostId, String reason) async {
+    const url = '/api/farm-club/report/mission';
+
+    final body = jsonEncode({
+      'missionPostId': missionPostId,
+      'reason': reason,
+    });
+
+    final response = await apiClient.post(url, body: body);
+
+    if (response.statusCode == 200) {
+      return utf8.decode(response.bodyBytes);
+    } else {
+      throw Exception('미션 글 신고 실패');
+    }
+  }
+
+  Future<String> missionCommentReport(int missionPostCommentId, String reason) async {
+    const url = '/api/farm-club/report/comment';
+
+    final body = jsonEncode({
+      'missionPostCommentId': missionPostCommentId,
+      'reason': reason,
+    });
+
+    final response = await apiClient.post(url, body: body);
+
+    if (response.statusCode == 200) {
+      return utf8.decode(response.bodyBytes);
+    } else {
+      throw Exception('미션 댓글 신고 실패');
+    }
+  }
 }

--- a/lib/model/mission/mission_post_report_model.dart
+++ b/lib/model/mission/mission_post_report_model.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'mission_post_report_model.freezed.dart';
+part 'mission_post_report_model.g.dart';
+
+@freezed
+class MissionPostReportModel with _$MissionPostReportModel {
+  const factory MissionPostReportModel({
+    required int missionPostId,
+    required String reason,
+  }) = _MissionPostReportModel;
+
+  factory MissionPostReportModel.fromJson(Map<String, dynamic> json) =>
+      _$MissionPostReportModelFromJson(json);
+}

--- a/lib/model/mission/mission_post_report_model.freezed.dart
+++ b/lib/model/mission/mission_post_report_model.freezed.dart
@@ -1,0 +1,177 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'mission_post_report_model.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+MissionPostReportModel _$MissionPostReportModelFromJson(
+    Map<String, dynamic> json) {
+  return _MissionPostReportModel.fromJson(json);
+}
+
+/// @nodoc
+mixin _$MissionPostReportModel {
+  int get missionPostId => throw _privateConstructorUsedError;
+  String get reason => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $MissionPostReportModelCopyWith<MissionPostReportModel> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $MissionPostReportModelCopyWith<$Res> {
+  factory $MissionPostReportModelCopyWith(MissionPostReportModel value,
+          $Res Function(MissionPostReportModel) then) =
+      _$MissionPostReportModelCopyWithImpl<$Res, MissionPostReportModel>;
+  @useResult
+  $Res call({int missionPostId, String reason});
+}
+
+/// @nodoc
+class _$MissionPostReportModelCopyWithImpl<$Res,
+        $Val extends MissionPostReportModel>
+    implements $MissionPostReportModelCopyWith<$Res> {
+  _$MissionPostReportModelCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? missionPostId = null,
+    Object? reason = null,
+  }) {
+    return _then(_value.copyWith(
+      missionPostId: null == missionPostId
+          ? _value.missionPostId
+          : missionPostId // ignore: cast_nullable_to_non_nullable
+              as int,
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$MissionPostReportModelImplCopyWith<$Res>
+    implements $MissionPostReportModelCopyWith<$Res> {
+  factory _$$MissionPostReportModelImplCopyWith(
+          _$MissionPostReportModelImpl value,
+          $Res Function(_$MissionPostReportModelImpl) then) =
+      __$$MissionPostReportModelImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int missionPostId, String reason});
+}
+
+/// @nodoc
+class __$$MissionPostReportModelImplCopyWithImpl<$Res>
+    extends _$MissionPostReportModelCopyWithImpl<$Res,
+        _$MissionPostReportModelImpl>
+    implements _$$MissionPostReportModelImplCopyWith<$Res> {
+  __$$MissionPostReportModelImplCopyWithImpl(
+      _$MissionPostReportModelImpl _value,
+      $Res Function(_$MissionPostReportModelImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? missionPostId = null,
+    Object? reason = null,
+  }) {
+    return _then(_$MissionPostReportModelImpl(
+      missionPostId: null == missionPostId
+          ? _value.missionPostId
+          : missionPostId // ignore: cast_nullable_to_non_nullable
+              as int,
+      reason: null == reason
+          ? _value.reason
+          : reason // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$MissionPostReportModelImpl implements _MissionPostReportModel {
+  const _$MissionPostReportModelImpl(
+      {required this.missionPostId, required this.reason});
+
+  factory _$MissionPostReportModelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$MissionPostReportModelImplFromJson(json);
+
+  @override
+  final int missionPostId;
+  @override
+  final String reason;
+
+  @override
+  String toString() {
+    return 'MissionPostReportModel(missionPostId: $missionPostId, reason: $reason)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$MissionPostReportModelImpl &&
+            (identical(other.missionPostId, missionPostId) ||
+                other.missionPostId == missionPostId) &&
+            (identical(other.reason, reason) || other.reason == reason));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, missionPostId, reason);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$MissionPostReportModelImplCopyWith<_$MissionPostReportModelImpl>
+      get copyWith => __$$MissionPostReportModelImplCopyWithImpl<
+          _$MissionPostReportModelImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$MissionPostReportModelImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _MissionPostReportModel implements MissionPostReportModel {
+  const factory _MissionPostReportModel(
+      {required final int missionPostId,
+      required final String reason}) = _$MissionPostReportModelImpl;
+
+  factory _MissionPostReportModel.fromJson(Map<String, dynamic> json) =
+      _$MissionPostReportModelImpl.fromJson;
+
+  @override
+  int get missionPostId;
+  @override
+  String get reason;
+  @override
+  @JsonKey(ignore: true)
+  _$$MissionPostReportModelImplCopyWith<_$MissionPostReportModelImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/model/mission/mission_post_report_model.g.dart
+++ b/lib/model/mission/mission_post_report_model.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_post_report_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$MissionPostReportModelImpl _$$MissionPostReportModelImplFromJson(
+        Map<String, dynamic> json) =>
+    _$MissionPostReportModelImpl(
+      missionPostId: (json['missionPostId'] as num).toInt(),
+      reason: json['reason'] as String,
+    );
+
+Map<String, dynamic> _$$MissionPostReportModelImplToJson(
+        _$MissionPostReportModelImpl instance) =>
+    <String, dynamic>{
+      'missionPostId': instance.missionPostId,
+      'reason': instance.reason,
+    };

--- a/lib/repository/my_farmclub_repository.dart
+++ b/lib/repository/my_farmclub_repository.dart
@@ -93,4 +93,14 @@ static Future<String> missionCommentDelete(int missionPostCommentId) async {
     String? response = await MyFarmclubService().farmclubUserList(farmClubId);
     return response;
   }
+
+  static Future<String> missionReport(int missionPostId, String reason) async {
+    String? response = await MyFarmclubService().missionReport(missionPostId, reason);
+    return response;
+  }
+
+  static Future<String> missionCommentReport(int missionPostCommentId, String reason) async {
+    String? response = await MyFarmclubService().missionCommentReport(missionPostCommentId, reason);
+    return response;
+  }
 }

--- a/lib/view/farmclub/component/feed_profile.dart
+++ b/lib/view/farmclub/component/feed_profile.dart
@@ -14,7 +14,9 @@ class FeedProfile extends ConsumerWidget {
     required this.nickname,
     required this.writeDateTime,
     required this.myComment,
+    required this.myPost,
     required this.commentId,
+    this.feedId,
     required this.categoryType,
   });
 
@@ -23,7 +25,9 @@ class FeedProfile extends ConsumerWidget {
   final String nickname;
   final String writeDateTime;
   final bool myComment;
+  final bool myPost;
   final int commentId;
+  final int? feedId;
   final String categoryType;
 
   @override
@@ -47,21 +51,39 @@ class FeedProfile extends ConsumerWidget {
                       nickname,
                       style: FarmusThemeTextStyle.darkMedium15,
                     ),
-                    isDetail
-                        ? GestureDetector(
-                            onTap: myComment
-                                ? () {
-                                    showDeleteBottomSheet(context, commentId,
-                                        null, '댓글', categoryType);
-                                  }
-                                : () {
-                                    showReportBottomSheet(
-                                        context, '댓글 신고', '댓글을 신고했어요');
-                                  },
-                            child: SvgPicture.asset(
-                                'assets/image/ic_more_vertical.svg'),
-                          )
-                        : Container(),
+                    if (isDetail)
+                      GestureDetector(
+                        onTap: () {
+                          if (myComment) {
+                            showDeleteBottomSheet(
+                              context,
+                              commentId,
+                              null,
+                              '댓글',
+                              categoryType,
+                            );
+                          } else if (myPost) {
+                            showDeleteBottomSheet(
+                              context,
+                              feedId!,
+                              null,
+                              '게시물',
+                              categoryType,
+                            );
+                          } else {
+                            showReportBottomSheet(
+                              context,
+                              myComment ? '댓글 신고' : '게시물 신고',
+                              myPost
+                                  ? '댓글을 신고했어요'
+                                  : '게시물을 신고했어요',
+                            );
+                          }
+                        },
+                        child: SvgPicture.asset(
+                          'assets/image/ic_more_vertical.svg',
+                        ),
+                      ),
                   ],
                 ),
                 Text(

--- a/lib/view/farmclub/component/feed_profile.dart
+++ b/lib/view/farmclub/component/feed_profile.dart
@@ -16,7 +16,7 @@ class FeedProfile extends ConsumerWidget {
     required this.myComment,
     required this.myPost,
     required this.commentId,
-    this.feedId,
+    required this.feedId,
     required this.categoryType,
   });
 
@@ -27,7 +27,7 @@ class FeedProfile extends ConsumerWidget {
   final bool myComment;
   final bool myPost;
   final int commentId;
-  final int? feedId;
+  final int feedId;
   final String categoryType;
 
   @override
@@ -65,19 +65,14 @@ class FeedProfile extends ConsumerWidget {
                           } else if (myPost) {
                             showDeleteBottomSheet(
                               context,
-                              feedId!,
+                              feedId,
                               null,
                               '게시물',
                               categoryType,
                             );
-                          } else {
+                          } else{
                             showReportBottomSheet(
-                              context,
-                              myComment ? '댓글 신고' : '게시물 신고',
-                              myPost
-                                  ? '댓글을 신고했어요'
-                                  : '게시물을 신고했어요',
-                            );
+                                context, '댓글 신고', '댓글을 신고했어요', commentId, 'missionComment');
                           }
                         },
                         child: SvgPicture.asset(

--- a/lib/view/farmclub/farmclub_screen.dart
+++ b/lib/view/farmclub/farmclub_screen.dart
@@ -143,6 +143,7 @@ class FarmclubScreen extends ConsumerWidget {
                                             myLike: diary.myLike,
                                             state: diary.state,
                                             categoryType: 'diary',
+                                            myPost: true,
                                           );
                                         }).toList(),
                                       )

--- a/lib/view/feed_detail/component/diary_comment.dart
+++ b/lib/view/feed_detail/component/diary_comment.dart
@@ -80,7 +80,9 @@ class DiaryComment extends ConsumerWidget {
                                 commentsData.diaryCommentContent.length - 1,
                             myComment: comment.myComment,
                             commentId: comment.commentId,
+                            feedId: -1,
                             categoryType: "diary",
+                            myPost: true,
                           ),
                         );
                       }).toList(),

--- a/lib/view/feed_detail/component/feed_detail_comment.dart
+++ b/lib/view/feed_detail/component/feed_detail_comment.dart
@@ -14,7 +14,9 @@ class FeedDetailComment extends ConsumerWidget {
     required this.content,
     this.isLast = false,
     required this.myComment,
+    required this.myPost,
     required this.commentId,
+    required this.feedId,
     required this.categoryType,
   });
 
@@ -24,7 +26,9 @@ class FeedDetailComment extends ConsumerWidget {
   final String content;
   final bool isLast;
   final bool myComment;
+  final bool myPost;
   final int commentId;
+  final int feedId;
   final String categoryType;
 
   @override
@@ -38,7 +42,9 @@ class FeedDetailComment extends ConsumerWidget {
           writeDateTime: date,
           profileImage: profileImage,
           myComment: myComment,
+          myPost: myPost,
           commentId: commentId,
+          feedId: feedId,
           categoryType: categoryType,
         ),
         const SizedBox(

--- a/lib/view/feed_detail/feed_detail_screen.dart
+++ b/lib/view/feed_detail/feed_detail_screen.dart
@@ -29,6 +29,7 @@ class FeedDetailScreen extends ConsumerWidget {
     required this.myLike,
     this.state,
     required this.categoryType,
+    required this.myPost
   });
 
   final int feedId;
@@ -42,6 +43,7 @@ class FeedDetailScreen extends ConsumerWidget {
   final bool myLike;
   final String? state;
   final String categoryType;
+  final bool myPost;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -60,8 +62,11 @@ class FeedDetailScreen extends ConsumerWidget {
         actions: [
           IconButton(
             onPressed: () {
-              showDeleteBottomSheet(
-                  context, feedId, selectedVeggieId, '게시물', categoryType);
+              if (notifierType == "미션 인증" && !myPost) {
+                showReportBottomSheet(context, '게시물 신고', '게시물을 신고했어요');
+              } else {
+                showDeleteBottomSheet(context, feedId, selectedVeggieId, '게시물', categoryType);
+              }
             },
             icon: SvgPicture.asset('assets/image/ic_more_vertical.svg'),
           )
@@ -83,7 +88,9 @@ class FeedDetailScreen extends ConsumerWidget {
                         nickname: nickname,
                         writeDateTime: writeDateTime,
                         myComment: false,
+                        myPost: false,
                         commentId: commentCount,
+                        feedId: feedId,
                         categoryType: categoryType),
                     const SizedBox(
                       height: 16.0,

--- a/lib/view/feed_detail/feed_detail_screen.dart
+++ b/lib/view/feed_detail/feed_detail_screen.dart
@@ -61,7 +61,6 @@ class FeedDetailScreen extends ConsumerWidget {
     }
 
     final String notifierType = state != null ? "성장 일기" : "미션 인증";
-    print(myPost);
     return Scaffold(
       appBar: BackLeftTitleAppBar(
         actions: [
@@ -140,6 +139,7 @@ class FeedDetailScreen extends ConsumerWidget {
                         : MissionComment(
                             missionPostCommentId: feedId,
                             commentCount: commentCount,
+                            likeCount: likeCount,
                             myLike: myLike,
                           ),
                   ],

--- a/lib/view/feed_detail/feed_detail_screen.dart
+++ b/lib/view/feed_detail/feed_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:farmus/common/app_bar/back_left_title_app_bar.dart';
 import 'package:farmus/common/form/comment_text_form_field.dart';
+import 'package:farmus/model/my_farmclub/mission_feed.dart';
 import 'package:farmus/view/farmclub/component/feed_profile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -10,6 +11,7 @@ import '../../common/theme/farmus_theme_color.dart';
 import '../../common/theme/farmus_theme_text_style.dart';
 import '../../model/home/my_veggie_list_model.dart';
 import '../../view_model/home/home_provider.dart';
+import '../../view_model/my_farmclub/mission_feed_notifier.dart';
 import '../../view_model/my_vege/notifier/my_veggie_list.dart';
 import '../mission_feed/component/mission_comment.dart';
 import 'component/diary_comment.dart';
@@ -48,22 +50,25 @@ class FeedDetailScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     var selectedVeggieId = ref.watch(selectedVegeIdProvider);
+
     final AsyncValue<List<MyVeggieListModel>> veggieList =
         ref.watch(myVeggieListModelProvider);
+
+
 
     if (selectedVeggieId == null && veggieList.value?.isNotEmpty == true) {
       selectedVeggieId = veggieList.value!.first.myVeggieId;
     }
 
     final String notifierType = state != null ? "성장 일기" : "미션 인증";
-
+    print(myPost);
     return Scaffold(
       appBar: BackLeftTitleAppBar(
         actions: [
           IconButton(
             onPressed: () {
               if (notifierType == "미션 인증" && !myPost) {
-                showReportBottomSheet(context, '게시물 신고', '게시물을 신고했어요');
+                showReportBottomSheet(context, '게시물 신고', '게시물을 신고했어요', feedId, 'missionPost');
               } else {
                 showDeleteBottomSheet(context, feedId, selectedVeggieId, '게시물', categoryType);
               }
@@ -88,7 +93,7 @@ class FeedDetailScreen extends ConsumerWidget {
                         nickname: nickname,
                         writeDateTime: writeDateTime,
                         myComment: false,
-                        myPost: false,
+                        myPost: myPost,
                         commentId: commentCount,
                         feedId: feedId,
                         categoryType: categoryType),

--- a/lib/view/mission_feed/component/mission_comment.dart
+++ b/lib/view/mission_feed/component/mission_comment.dart
@@ -16,11 +16,13 @@ class MissionComment extends ConsumerWidget {
     super.key,
     required this.missionPostCommentId,
     required this.commentCount,
+    required this.likeCount,
     required this.myLike,
   });
 
   final int missionPostCommentId;
   final int commentCount;
+  final int likeCount;
   final bool myLike;
 
   @override
@@ -35,13 +37,29 @@ class MissionComment extends ConsumerWidget {
     return missionFeed.when(
       data: (feeds) {
         if (feeds.isEmpty) {
-          return const Center(child: Text('No feed data available.'));
+          return const Center(
+            child: Text(
+              '작성된 댓글이 없어요',
+              style: FarmusThemeTextStyle.gray2Medium13,
+            ),
+          );
         }
 
-        // Find the feed that matches the given missionPostCommentId
         final feed = feeds.firstWhere(
               (feed) => feed.missionPostId == missionPostCommentId,
-          orElse: () => feeds[0],
+          orElse: () => MissionFeed(
+            missionPostId: missionPostCommentId,
+            userId: 0,
+            stepNum: 0,
+            nickname: '',
+            profileImage: '',
+            date: '',
+            image: '',
+            content: '',
+            likeCount: likeCount,
+            commentCount: commentCount,
+            isLiked: false,
+          ),
         );
 
         return Column(
@@ -111,13 +129,13 @@ class MissionComment extends ConsumerWidget {
                 );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, stack) => Center(child: Text('Error: $error')),
+              error: (error, stack) => Center(child: Text('삭제된 게시물입니다.')),
             ),
           ],
         );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
-      error: (error, stack) => Center(child: Text('Error: $error')),
+      error: (error, stack) => Center(child: Text('Error2: $error')),
     );
   }
 }

--- a/lib/view/mission_feed/component/mission_comment.dart
+++ b/lib/view/mission_feed/component/mission_comment.dart
@@ -1,3 +1,4 @@
+import 'package:farmus/model/my_farmclub/mission_feed.dart';
 import 'package:farmus/model/my_farmclub/mission_data_model.dart';
 import 'package:farmus/view/feed_detail/component/feed_detail_comment.dart';
 import 'package:farmus/view/feed_detail/component/feed_detail_icon.dart';
@@ -6,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../common/theme/farmus_theme_color.dart';
 import '../../../common/theme/farmus_theme_text_style.dart';
-import '../../../model/my_farmclub/mission_feed.dart';
 import '../../../view_model/home/home_provider.dart';
 import '../../../view_model/my_farmclub/mission_comment_notifier.dart';
 import '../../../view_model/my_farmclub/mission_feed_notifier.dart';
@@ -28,9 +28,9 @@ class MissionComment extends ConsumerWidget {
     final selectedFarmclubId = ref.watch(selectedFarmclubIdProvider);
 
     final AsyncValue<List<MissionFeed>> missionFeed =
-        ref.watch(missionFeedProvider(selectedFarmclubId));
+    ref.watch(missionFeedProvider(selectedFarmclubId));
     final AsyncValue<MissionDataModel> missionData =
-        ref.watch(missionCommentNotifierProvider(missionPostCommentId));
+    ref.watch(missionCommentNotifierProvider(missionPostCommentId));
 
     return missionFeed.when(
       data: (feeds) {
@@ -38,8 +38,9 @@ class MissionComment extends ConsumerWidget {
           return const Center(child: Text('No feed data available.'));
         }
 
+        // Find the feed that matches the given missionPostCommentId
         final feed = feeds.firstWhere(
-          (feed) => feed.missionPostId == missionPostCommentId,
+              (feed) => feed.missionPostId == missionPostCommentId,
           orElse: () => feeds[0],
         );
 
@@ -76,36 +77,38 @@ class MissionComment extends ConsumerWidget {
             missionData.when(
               data: (data) {
                 final List<MissionCommentModel> comments = data.comments;
-
                 return comments.isNotEmpty
                     ? Column(
-                        children: comments.asMap().entries.map((entry) {
-                          int idx = entry.key;
-                          MissionCommentModel comment = entry.value;
-                          return Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 8.0),
-                            child: FeedDetailComment(
-                              profileImage: comment.profileImage,
-                              nickname: comment.nickname,
-                              date: comment.date,
-                              content: comment.content,
-                              isLast: idx == comments.length - 1,
-                              myComment: comment.isMyComment,
-                              commentId: comment.missionPostCommentId,
-                              categoryType: 'mission',
-                            ),
-                          );
-                        }).toList(),
-                      )
+                  children: comments.asMap().entries.map((entry) {
+                    int idx = entry.key;
+                    MissionCommentModel comment = entry.value;
+
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                      child: FeedDetailComment(
+                        feedId: feed.missionPostId,
+                        profileImage: comment.profileImage,
+                        nickname: comment.nickname,
+                        date: comment.date,
+                        content: comment.content,
+                        isLast: idx == comments.length - 1,
+                        myComment: comment.isMyComment,
+                        commentId: comment.missionPostCommentId,
+                        categoryType: 'mission',
+                        myPost: comment.isMyComment,
+                      ),
+                    );
+                  }).toList(),
+                )
                     : const Center(
-                        child: Padding(
-                          padding: EdgeInsets.only(top: 24.0),
-                          child: Text(
-                            '작성된 댓글이 없어요',
-                            style: FarmusThemeTextStyle.gray2Medium13,
-                          ),
-                        ),
-                      );
+                  child: Padding(
+                    padding: EdgeInsets.only(top: 24.0),
+                    child: Text(
+                      '작성된 댓글이 없어요',
+                      style: FarmusThemeTextStyle.gray2Medium13,
+                    ),
+                  ),
+                );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
               error: (error, stack) => Center(child: Text('Error: $error')),

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -56,9 +56,13 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                       children: [
                         missionUserList.when(
                           data: (users) {
-                            final myUserId =  ref.watch(missionUserListModelProvider(selectedFarmclubId));
+                            final myUserId = ref.watch(
+                                missionUserListModelProvider(
+                                    selectedFarmclubId));
 
-                            final otherUsers = users.where((user) => user.userId != myUserId).toList();
+                            final otherUsers = users
+                                .where((user) => user.userId != myUserId)
+                                .toList();
 
                             List<MissionUserListModel> sortedUsers = [
                               ...otherUsers,
@@ -108,6 +112,8 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                           ]
                         : filteredFeeds.map((feed) {
                             final user = missionUserList.value?.first;
+                            print(user?.userId);
+                            print(feed.userId);
 
                             return FarmusFeed(
                               feedId: feed.missionPostId,

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -89,7 +89,6 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                           loading: () => const CircularProgressIndicator(),
                           error: (err, stack) => Text('Error: $err'),
                         ),
-
                       ],
                     ),
                   ),
@@ -108,6 +107,8 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                             )
                           ]
                         : filteredFeeds.map((feed) {
+                            final user = missionUserList.value?.first;
+
                             return FarmusFeed(
                               feedId: feed.missionPostId,
                               profileImage: feed.profileImage,
@@ -119,6 +120,7 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                               likeCount: feed.likeCount,
                               myLike: feed.isLiked,
                               categoryType: 'mission',
+                              myPost: user?.userId == feed.userId,
                             );
                           }).toList(),
                   ),
@@ -159,6 +161,8 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                           )
                         : Column(
                             children: stepFeeds.map((feed) {
+                              final user = missionUserList.value?.first;
+
                               return FarmusFeed(
                                 feedId: feed.missionPostId,
                                 profileImage: feed.profileImage,
@@ -170,6 +174,7 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                                 likeCount: feed.likeCount,
                                 myLike: feed.isLiked,
                                 categoryType: 'mission',
+                                myPost: user?.userId == feed.userId,
                               );
                             }).toList(),
                           ),

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -112,8 +112,6 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                           ]
                         : filteredFeeds.map((feed) {
                             final user = missionUserList.value?.first;
-                            print(user?.userId);
-                            print(feed.userId);
 
                             return FarmusFeed(
                               feedId: feed.missionPostId,

--- a/lib/view/mission_feed/component/mission_feed_tab_bar.dart
+++ b/lib/view/mission_feed/component/mission_feed_tab_bar.dart
@@ -56,52 +56,40 @@ class _MissionFeedTabBarState extends ConsumerState<MissionFeedTabBar> {
                       children: [
                         missionUserList.when(
                           data: (users) {
-                            if (feeds.isNotEmpty) {
-                              final firstFeedUserId = feeds.first.userId;
+                            final myUserId =  ref.watch(missionUserListModelProvider(selectedFarmclubId));
 
-                              final myAccount = users.firstWhere(
-                                (user) => user.userId == firstFeedUserId,
-                                orElse: () => users.first,
-                              );
+                            final otherUsers = users.where((user) => user.userId != myUserId).toList();
 
-                              final otherUsers = users
-                                  .where(
-                                      (user) => user.userId != firstFeedUserId)
-                                  .toList();
+                            List<MissionUserListModel> sortedUsers = [
+                              ...otherUsers,
+                            ];
 
-                              List<MissionUserListModel> sortedUsers = [
-                                myAccount,
-                                ...otherUsers
-                              ];
+                            return Row(
+                              children: sortedUsers.map((user) {
+                                bool isSelected = selectedUserId == user.userId;
 
-                              return Row(
-                                children: sortedUsers.map((user) {
-                                  bool isSelected =
-                                      selectedUserId == user.userId;
-
-                                  return GestureDetector(
-                                    onTap: () {
-                                      setState(() {
-                                        if (selectedUserId == user.userId) {
-                                          selectedUserId = null;
-                                        } else {
-                                          selectedUserId = user.userId;
-                                        }
-                                      });
-                                    },
-                                    child: MissionFeedSelectProfile(
-                                      user: user,
-                                      isSelected: isSelected,
-                                    ),
-                                  );
-                                }).toList(),
-                              );
-                            }
-                            return const SizedBox.shrink();
+                                return GestureDetector(
+                                  onTap: () {
+                                    setState(() {
+                                      if (selectedUserId == user.userId) {
+                                        selectedUserId = null;
+                                      } else {
+                                        selectedUserId = user.userId;
+                                      }
+                                    });
+                                  },
+                                  child: MissionFeedSelectProfile(
+                                    user: user,
+                                    isSelected: isSelected,
+                                  ),
+                                );
+                              }).toList(),
+                            );
                           },
                           loading: () => const CircularProgressIndicator(),
                           error: (err, stack) => Text('Error: $err'),
                         ),
+
                       ],
                     ),
                   ),

--- a/lib/view/vege_diary/component/vege_diary_widget.dart
+++ b/lib/view/vege_diary/component/vege_diary_widget.dart
@@ -38,6 +38,7 @@ class VegeDiaryWidget extends ConsumerWidget {
               myLike: diary.myLike,
               state: diary.state,
               categoryType: 'diary',
+              myPost: true,
             ),
           ),
         );

--- a/lib/view_model/mission_feed/mission_comment_report_notifier.dart
+++ b/lib/view_model/mission_feed/mission_comment_report_notifier.dart
@@ -1,0 +1,14 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../repository/my_farmclub_repository.dart';
+
+part 'mission_comment_report_notifier.g.dart';
+
+@riverpod
+Future<String> missionCommentReportNotifier(
+    MissionCommentReportNotifierRef ref, int missionPostCommentId, String reason) async {
+  final response =
+  await MyFarmclubRepository.missionCommentReport(missionPostCommentId, reason);
+  return response;
+
+}

--- a/lib/view_model/mission_feed/mission_comment_report_notifier.g.dart
+++ b/lib/view_model/mission_feed/mission_comment_report_notifier.g.dart
@@ -1,0 +1,180 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_comment_report_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$missionCommentReportNotifierHash() =>
+    r'287f4d3ec15bc408b23336a39cbbbf7c1efde95e';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [missionCommentReportNotifier].
+@ProviderFor(missionCommentReportNotifier)
+const missionCommentReportNotifierProvider =
+    MissionCommentReportNotifierFamily();
+
+/// See also [missionCommentReportNotifier].
+class MissionCommentReportNotifierFamily extends Family<AsyncValue<String>> {
+  /// See also [missionCommentReportNotifier].
+  const MissionCommentReportNotifierFamily();
+
+  /// See also [missionCommentReportNotifier].
+  MissionCommentReportNotifierProvider call(
+    int missionPostCommentId,
+    String reason,
+  ) {
+    return MissionCommentReportNotifierProvider(
+      missionPostCommentId,
+      reason,
+    );
+  }
+
+  @override
+  MissionCommentReportNotifierProvider getProviderOverride(
+    covariant MissionCommentReportNotifierProvider provider,
+  ) {
+    return call(
+      provider.missionPostCommentId,
+      provider.reason,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'missionCommentReportNotifierProvider';
+}
+
+/// See also [missionCommentReportNotifier].
+class MissionCommentReportNotifierProvider
+    extends AutoDisposeFutureProvider<String> {
+  /// See also [missionCommentReportNotifier].
+  MissionCommentReportNotifierProvider(
+    int missionPostCommentId,
+    String reason,
+  ) : this._internal(
+          (ref) => missionCommentReportNotifier(
+            ref as MissionCommentReportNotifierRef,
+            missionPostCommentId,
+            reason,
+          ),
+          from: missionCommentReportNotifierProvider,
+          name: r'missionCommentReportNotifierProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$missionCommentReportNotifierHash,
+          dependencies: MissionCommentReportNotifierFamily._dependencies,
+          allTransitiveDependencies:
+              MissionCommentReportNotifierFamily._allTransitiveDependencies,
+          missionPostCommentId: missionPostCommentId,
+          reason: reason,
+        );
+
+  MissionCommentReportNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.missionPostCommentId,
+    required this.reason,
+  }) : super.internal();
+
+  final int missionPostCommentId;
+  final String reason;
+
+  @override
+  Override overrideWith(
+    FutureOr<String> Function(MissionCommentReportNotifierRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: MissionCommentReportNotifierProvider._internal(
+        (ref) => create(ref as MissionCommentReportNotifierRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        missionPostCommentId: missionPostCommentId,
+        reason: reason,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<String> createElement() {
+    return _MissionCommentReportNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MissionCommentReportNotifierProvider &&
+        other.missionPostCommentId == missionPostCommentId &&
+        other.reason == reason;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, missionPostCommentId.hashCode);
+    hash = _SystemHash.combine(hash, reason.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin MissionCommentReportNotifierRef on AutoDisposeFutureProviderRef<String> {
+  /// The parameter `missionPostCommentId` of this provider.
+  int get missionPostCommentId;
+
+  /// The parameter `reason` of this provider.
+  String get reason;
+}
+
+class _MissionCommentReportNotifierProviderElement
+    extends AutoDisposeFutureProviderElement<String>
+    with MissionCommentReportNotifierRef {
+  _MissionCommentReportNotifierProviderElement(super.provider);
+
+  @override
+  int get missionPostCommentId =>
+      (origin as MissionCommentReportNotifierProvider).missionPostCommentId;
+  @override
+  String get reason => (origin as MissionCommentReportNotifierProvider).reason;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/mission_feed/mission_post_report_notifier.dart
+++ b/lib/view_model/mission_feed/mission_post_report_notifier.dart
@@ -1,0 +1,14 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../repository/my_farmclub_repository.dart';
+
+part 'mission_post_report_notifier.g.dart';
+
+@riverpod
+Future<String> missionPostReportModel(
+    MissionPostReportModelRef ref, int missionPostId, String reason) async {
+  final response =
+      await MyFarmclubRepository.missionReport(missionPostId, reason);
+  return response;
+
+}

--- a/lib/view_model/mission_feed/mission_post_report_notifier.g.dart
+++ b/lib/view_model/mission_feed/mission_post_report_notifier.g.dart
@@ -1,0 +1,178 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'mission_post_report_notifier.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$missionPostReportModelHash() =>
+    r'9de464a7f30e2daaec1e68f4e56ad4b3c4513bf0';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+/// See also [missionPostReportModel].
+@ProviderFor(missionPostReportModel)
+const missionPostReportModelProvider = MissionPostReportModelFamily();
+
+/// See also [missionPostReportModel].
+class MissionPostReportModelFamily extends Family<AsyncValue<String>> {
+  /// See also [missionPostReportModel].
+  const MissionPostReportModelFamily();
+
+  /// See also [missionPostReportModel].
+  MissionPostReportModelProvider call(
+    int missionPostId,
+    String reason,
+  ) {
+    return MissionPostReportModelProvider(
+      missionPostId,
+      reason,
+    );
+  }
+
+  @override
+  MissionPostReportModelProvider getProviderOverride(
+    covariant MissionPostReportModelProvider provider,
+  ) {
+    return call(
+      provider.missionPostId,
+      provider.reason,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'missionPostReportModelProvider';
+}
+
+/// See also [missionPostReportModel].
+class MissionPostReportModelProvider extends AutoDisposeFutureProvider<String> {
+  /// See also [missionPostReportModel].
+  MissionPostReportModelProvider(
+    int missionPostId,
+    String reason,
+  ) : this._internal(
+          (ref) => missionPostReportModel(
+            ref as MissionPostReportModelRef,
+            missionPostId,
+            reason,
+          ),
+          from: missionPostReportModelProvider,
+          name: r'missionPostReportModelProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$missionPostReportModelHash,
+          dependencies: MissionPostReportModelFamily._dependencies,
+          allTransitiveDependencies:
+              MissionPostReportModelFamily._allTransitiveDependencies,
+          missionPostId: missionPostId,
+          reason: reason,
+        );
+
+  MissionPostReportModelProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.missionPostId,
+    required this.reason,
+  }) : super.internal();
+
+  final int missionPostId;
+  final String reason;
+
+  @override
+  Override overrideWith(
+    FutureOr<String> Function(MissionPostReportModelRef provider) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: MissionPostReportModelProvider._internal(
+        (ref) => create(ref as MissionPostReportModelRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        missionPostId: missionPostId,
+        reason: reason,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<String> createElement() {
+    return _MissionPostReportModelProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is MissionPostReportModelProvider &&
+        other.missionPostId == missionPostId &&
+        other.reason == reason;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, missionPostId.hashCode);
+    hash = _SystemHash.combine(hash, reason.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin MissionPostReportModelRef on AutoDisposeFutureProviderRef<String> {
+  /// The parameter `missionPostId` of this provider.
+  int get missionPostId;
+
+  /// The parameter `reason` of this provider.
+  String get reason;
+}
+
+class _MissionPostReportModelProviderElement
+    extends AutoDisposeFutureProviderElement<String>
+    with MissionPostReportModelRef {
+  _MissionPostReportModelProviderElement(super.provider);
+
+  @override
+  int get missionPostId =>
+      (origin as MissionPostReportModelProvider).missionPostId;
+  @override
+  String get reason => (origin as MissionPostReportModelProvider).reason;
+}
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
@@ -1,6 +1,5 @@
-import 'package:farmus/view_model/my_farmclub/farmclub_mission_certification_notifier.dart';
+import 'package:farmus/view_model/mission_write/notifier/mission_commemt_delete_notifier.dart';
 import 'package:farmus/view_model/my_farmclub/mission_feed_notifier.dart';
-import 'package:farmus/view_model/my_farmclub/my_farmclub_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../data/network/my_farmclub_service.dart';
@@ -17,8 +16,6 @@ class MissionDeleteNotifier extends _$MissionDeleteNotifier {
   Future<void> missionDelete(int missionPostId) async {
     await MyFarmclubService().missionDelete(missionPostId);
     ref.invalidate(missionFeedProvider);
-    // ref.invalidate(myFarmclubModelProvider);
-    ref.invalidate(farmclubMissionCertificationNotifierProvider);
     ref.invalidateSelf();
   }
 }

--- a/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
+++ b/lib/view_model/mission_write/notifier/mission_delete_notifier.dart
@@ -17,7 +17,7 @@ class MissionDeleteNotifier extends _$MissionDeleteNotifier {
   Future<void> missionDelete(int missionPostId) async {
     await MyFarmclubService().missionDelete(missionPostId);
     ref.invalidate(missionFeedProvider);
-    ref.invalidate(myFarmclubModelProvider);
+    // ref.invalidate(myFarmclubModelProvider);
     ref.invalidate(farmclubMissionCertificationNotifierProvider);
     ref.invalidateSelf();
   }


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #272


### 🍠 Summary
미션 글 & 댓글 신고 API 연동을 하였습니다.
서버 측에서 정책에 맞게 신고하면 본인에게는 더이상 보이지 않는 게시물과 댓글이 되게 구현을 하였다고 합니다.
(삭제와 다른 개념! 다른 사람한테는 보임!)
삭제 자체는 n번 이상 신고 누적일 때로 구현했다고 서버 측에서 말해줬습니다.
따라서 게시물과 댓글을 신고하고 다시 미션 피드를 보면 신고한 게시물과 댓글이 보이지 않습니다.

하지만 아직 서버측에서 첫번째 사진과 같은 부분까지는 적용을 못했다고 하여 추후에 고쳐질 것 같습니다.
(신고하여 게시물이 삭제됐는데 계속 사진이 떠있는 상태)

![스크린샷 2024-09-13 오전 4 24 55](https://github.com/user-attachments/assets/1bca806f-e950-4b89-b209-b87b872e80ac)

또한, 두번째 사진 처럼 현재 댓글은 3개라고 되어있는데 1개만 보이는 것을 볼 수 있습니다. 이는 실제로 댓글은 3개인데 제가 2개의 댓글을 신고하여 사진처럼 보이는 것 입니다. 이 문제 또한 서버와 이야기를 해봐야할 것 같습니다.(아마 첫번째 문제와 같은 문제일 것 같음)
![스크린샷 2024-09-13 오전 4 29 41](https://github.com/user-attachments/assets/dab7e277-56b7-40bd-a777-1ae44de4abf9)

https://github.com/user-attachments/assets/d054bf77-9d85-4cfd-992d-6e9dac6105ae



### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [x] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
코드 참고하여, 아린님께서 성장일기에 대한 코드도 조건 달아가며 편하게 추가하시면 될 것 같습니다.